### PR TITLE
Fix: Analytics screen wiped by calendar render

### DIFF
--- a/frontend/src/features/workout-calendar.js
+++ b/frontend/src/features/workout-calendar.js
@@ -262,5 +262,28 @@ export async function loadWorkoutCalendar(hostEl) {
   }
 }
 
-// Legacy compat: function originally named loadWorkoutHistory(container)
-export const loadWorkoutHistory = loadWorkoutCalendar;
+/**
+ * Legacy compat: function originally named loadWorkoutHistory(container).
+ *
+ * The legacy callers pass the *Analytics tab* as the container, expecting
+ * this function to find the `#workoutCalendarContainer` placeholder INSIDE
+ * it and render there. If we naively treated the passed element as the
+ * render host we would wipe the entire Analytics screen — which is exactly
+ * what was happening in production (all sections disappeared except the
+ * calendar). Resolve the actual target before rendering.
+ *
+ * @param {HTMLElement} container - usually the Analytics tab div
+ */
+export async function loadWorkoutHistory(container) {
+  if (!container) return;
+
+  // Prefer an explicit placeholder inside the container; fall back to
+  // searching the entire document; only use the container itself if neither
+  // is found (fully legacy fallback).
+  const placeholder =
+    container.querySelector?.('#workoutCalendarContainer') ||
+    document.getElementById('workoutCalendarContainer') ||
+    container;
+
+  return loadWorkoutCalendar(placeholder);
+}


### PR DESCRIPTION
## Bug
The Analytics tab showed **only the Workout Calendar**. Every other section (Progress Comparison, 90-Day Overview, Volume by Muscle Group, Body Map, Top Exercises, Personal Records, Export & Reports) was missing.

## Root cause
\`analytics.js\` passes the *entire* \`#analytics\` tab div to \`window.loadWorkoutHistory(container)\` — matching the legacy signature where the function looked for the \`#workoutCalendarContainer\` placeholder inside the passed element.

The modular replacement, however, aliased \`loadWorkoutHistory\` directly to \`loadWorkoutCalendar(hostEl)\`, which treats \`hostEl\` as the render target and runs \`hostEl.innerHTML = renderCalendar()\` — **wiping everything the analytics screen just rendered**.

## Fix
\`loadWorkoutHistory(container)\` now:
1. Looks for \`#workoutCalendarContainer\` **inside** the passed container (matches legacy behavior).
2. Falls back to the global \`document.getElementById('#workoutCalendarContainer')\`.
3. Only uses the container itself as a last resort (pure legacy fallback).

\`loadWorkoutCalendar(hostEl)\` keeps its direct-render behavior for callers that pass an explicit target element.

## Verify
Visit Analytics after deploy — you should see all 7 sections restored (Progress Comparison → Export & Reports), with the Workout Calendar rendered *between* Volume by Muscle and Body Map where the placeholder sits.