### PR TITLE
Fix duplicate AI briefing modals (accumulated event listeners)

### DIFF
--- a/frontend/src/core/delegate.js
+++ b/frontend/src/core/delegate.js
@@ -1,0 +1,56 @@
+/**
+ * Delegated event handler registry.
+ *
+ * Screen modules call `delegate(container, 'click', handler)` on every
+ * render. Without this helper, each render would add another listener to
+ * the container (its innerHTML gets replaced but the container element
+ * itself persists), and over time clicks would fire N handlers producing
+ * N duplicate side effects (multiple modals, multiple API calls, etc.).
+ *
+ * This utility stores the current handler in a WeakMap keyed by the
+ * container + event type, removes the previous listener before attaching
+ * the new one, and is safe to call any number of times.
+ */
+
+const registry = new WeakMap();
+
+function getKey(element, type) {
+  let byType = registry.get(element);
+  if (!byType) {
+    byType = new Map();
+    registry.set(element, byType);
+  }
+  return byType;
+}
+
+/**
+ * Attach a single delegated handler of `type` to `element`, replacing any
+ * previously-attached handler for the same element/type combination.
+ *
+ * @param {EventTarget} element
+ * @param {string} type       - e.g. 'click', 'submit', 'change'
+ * @param {EventListener} handler
+ */
+export function delegate(element, type, handler) {
+  if (!element || typeof handler !== 'function') return;
+  const byType = getKey(element, type);
+  const previous = byType.get(type);
+  if (previous) element.removeEventListener(type, previous);
+  element.addEventListener(type, handler);
+  byType.set(type, handler);
+}
+
+/**
+ * Remove the delegated handler for `type` from `element`.
+ * @param {EventTarget} element
+ * @param {string} type
+ */
+export function undelegate(element, type) {
+  const byType = registry.get(element);
+  if (!byType) return;
+  const previous = byType.get(type);
+  if (previous) {
+    element.removeEventListener(type, previous);
+    byType.delete(type);
+  }
+}

--- a/frontend/src/features/nutrition/saved-meals.js
+++ b/frontend/src/features/nutrition/saved-meals.js
@@ -5,6 +5,7 @@
 
 import { html, raw } from '@core/html';
 import { api } from '@core/api';
+import { delegate } from '@core/delegate';
 import { openModal, confirmDialog, closeTopModal } from '@ui/Modal';
 import { toast } from '@ui/Toast';
 
@@ -50,7 +51,7 @@ export async function loadSavedMealsList() {
       </div>
     `);
 
-    container.addEventListener('click', async (event) => {
+    delegate(container, 'click', async (event) => {
       const btn = event.target.closest('[data-log-meal]');
       if (btn) {
         await logSavedMeal(parseInt(btn.getAttribute('data-log-meal'), 10));

--- a/frontend/src/features/start-workout.js
+++ b/frontend/src/features/start-workout.js
@@ -81,7 +81,17 @@ export async function startWorkoutFromProgram(programId) {
   }
 }
 
+// Module-level mutex to prevent concurrent startWorkoutDay calls. Without
+// this, duplicate click listeners (from tab re-renders) would spawn multiple
+// AI preview modals stacked on top of each other.
+let _startingWorkout = false;
+
 export async function startWorkoutDay(programId, programDayId) {
+  if (_startingWorkout) {
+    console.warn('startWorkoutDay called while another is in progress — ignoring');
+    return;
+  }
+  _startingWorkout = true;
   try {
     const programData = await withLoading('Starting your workout…', async () => {
       return await api.get(`/programs/${programId}`);
@@ -117,6 +127,8 @@ export async function startWorkoutDay(programId, programDayId) {
     }
   } catch (err) {
     toast.error(`Error starting workout: ${err.message}`);
+  } finally {
+    _startingWorkout = false;
   }
 }
 

--- a/frontend/src/features/workout-calendar.js
+++ b/frontend/src/features/workout-calendar.js
@@ -6,6 +6,7 @@
 import { html, raw } from '@core/html';
 import { api } from '@core/api';
 import { store } from '@core/state';
+import { delegate } from '@core/delegate';
 import { confirmDialog } from '@ui/Modal';
 import { toast } from '@ui/Toast';
 import {
@@ -157,7 +158,7 @@ function renderCalendar() {
 }
 
 function attachHandlers(container) {
-  container.addEventListener('click', async (event) => {
+  delegate(container, 'click', async (event) => {
     const target = event.target.closest('[data-action]');
     if (!target) return;
     const action = target.getAttribute('data-action');

--- a/frontend/src/screens/analytics.js
+++ b/frontend/src/screens/analytics.js
@@ -14,6 +14,7 @@
 
 import { html, raw } from '@core/html';
 import { api } from '@core/api';
+import { delegate } from '@core/delegate';
 import { toast } from '@ui/Toast';
 import { confirmDialog } from '@ui/Modal';
 import {
@@ -251,7 +252,7 @@ async function recalculatePRs() {
 }
 
 function attachAnalyticsHandlers(container) {
-  container.addEventListener('click', (event) => {
+  delegate(container, 'click', (event) => {
     const recalcBtn = event.target.closest('[data-action="recalc-prs"]');
     if (recalcBtn) {
       recalculatePRs();

--- a/frontend/src/screens/dashboard.js
+++ b/frontend/src/screens/dashboard.js
@@ -8,6 +8,7 @@
 
 import { html, raw } from '@core/html';
 import { api } from '@core/api';
+import { delegate } from '@core/delegate';
 import { formatWeight, formatDuration, formatDate, getExertionEmoji } from '@utils/formatters';
 
 function renderStatsOverview(overview) {
@@ -189,7 +190,7 @@ function renderErrorState(message) {
  * Attach delegated event handling for the dashboard.
  */
 function attachDashboardHandlers(container) {
-  container.addEventListener('click', (event) => {
+  delegate(container, 'click', (event) => {
     // Quick action buttons that call legacy globals directly
     const legacyBtn = event.target.closest('[data-legacy-call]');
     if (legacyBtn) {

--- a/frontend/src/screens/insights.js
+++ b/frontend/src/screens/insights.js
@@ -10,6 +10,7 @@
 import { html, raw } from '@core/html';
 import { api } from '@core/api';
 import { store } from '@core/state';
+import { delegate } from '@core/delegate';
 import { toast } from '@ui/Toast';
 
 const QUICK_QUESTIONS = [
@@ -121,7 +122,7 @@ function attachInsightsHandlers(container) {
   // Form submission
   const form = container.querySelector('#ai-chat-form');
   if (form) {
-    form.addEventListener('submit', (event) => {
+    delegate(form, 'submit', (event) => {
       event.preventDefault();
       const input = form.querySelector('#ai-chat-input');
       const msg = input.value.trim();
@@ -131,7 +132,7 @@ function attachInsightsHandlers(container) {
     });
   }
 
-  container.addEventListener('click', (event) => {
+  delegate(container, 'click', (event) => {
     const target = event.target.closest('[data-action]');
     if (!target) return;
     const action = target.getAttribute('data-action');

--- a/frontend/src/screens/learn.js
+++ b/frontend/src/screens/learn.js
@@ -10,6 +10,7 @@
  * — a simple render function is sufficient.
  */
 
+import { delegate } from '@core/delegate';
 import learnHtmlRaw from '../../content/learn.html?raw';
 
 const QUICK_NAV_SELECTORS = {
@@ -32,7 +33,7 @@ export function renderLearn(container) {
   // calls. These still work in the DOM since the HTML is unchanged, but we
   // also set up event delegation for data-action buttons to smooth out
   // future cleanup.
-  container.addEventListener('click', (event) => {
+  delegate(container, 'click', (event) => {
     const target = event.target.closest('[data-learn-scroll]');
     if (!target) return;
     event.preventDefault();

--- a/frontend/src/screens/nutrition.js
+++ b/frontend/src/screens/nutrition.js
@@ -10,6 +10,7 @@
 
 import { html, raw } from '@core/html';
 import { api } from '@core/api';
+import { delegate } from '@core/delegate';
 import { toast } from '@ui/Toast';
 import { progressRing } from '@ui/ProgressRing';
 import { formatDate, formatNumber } from '@utils/formatters';
@@ -278,7 +279,7 @@ async function logAllQuick() {
 }
 
 function attachNutritionHandlers(container) {
-  container.addEventListener('click', (event) => {
+  delegate(container, 'click', (event) => {
     const target = event.target.closest('[data-action]');
     if (!target) return;
     const action = target.getAttribute('data-action');

--- a/frontend/src/screens/programs.js
+++ b/frontend/src/screens/programs.js
@@ -9,6 +9,7 @@
 import { html, raw } from '@core/html';
 import { api } from '@core/api';
 import { store } from '@core/state';
+import { delegate } from '@core/delegate';
 import { openModal, confirmDialog } from '@ui/Modal';
 import { toast } from '@ui/Toast';
 import { formatDate } from '@utils/formatters';
@@ -149,7 +150,7 @@ export async function loadPrograms() {
 }
 
 function attachListHandlers(container) {
-  container.addEventListener('click', (event) => {
+  delegate(container, 'click', (event) => {
     const target = event.target.closest('[data-action]');
     if (!target) return;
     const action = target.getAttribute('data-action');

--- a/frontend/src/screens/workout.js
+++ b/frontend/src/screens/workout.js
@@ -10,6 +10,7 @@
 import { html, raw } from '@core/html';
 import { api } from '@core/api';
 import { store } from '@core/state';
+import { delegate } from '@core/delegate';
 import { toast } from '@ui/Toast';
 import { confirmDialog } from '@ui/Modal';
 import { formatDate, formatDuration } from '@utils/formatters';
@@ -304,7 +305,7 @@ function renderNoProgram() {
 }
 
 function attachHandlers(container, program) {
-  container.addEventListener('click', async (event) => {
+  delegate(container, 'click', async (event) => {
     const target = event.target.closest('[data-action]');
     if (!target) return;
     const action = target.getAttribute('data-action');


### PR DESCRIPTION
## Bug
Clicking **Start** on a program day opened 2-3 AI preview modals stacked on top of each other. You had to click **Skip Briefing** multiple times to get through to the workout warmup screen.

## Root cause
Every screen module's \`attachHandlers()\` was doing:

\`\`\`js
container.addEventListener('click', handler);
\`\`\`

on every render. The container element (\`#workout\`, \`#analytics\`, etc.) persists across renders — only its \`innerHTML\` changes. So each re-render added **another** click listener without removing the previous one.

After N renders, clicking a button fired N identical handlers — each opening its own AI preview modal.

**Worst offender**: \`frontend/src/screens/workout.js\`. Its \`renderTab()\` gets called on every sub-tab switch AND every day-card click, each time adding another listener. By the time you clicked **Start**, there were 3-5 stacked handlers.

## Fix (three parts)

### 1. New \`frontend/src/core/delegate.js\` utility
\`\`\`js
delegate(element, type, handler);
\`\`\`
- Stores the current handler in a WeakMap keyed by (element, type)
- On subsequent calls, removes the previous handler before attaching the new one
- Safe to call any number of times — no more accumulation

### 2. Updated every affected screen/feature
Replaced \`container.addEventListener('click', ...)\` with \`delegate(container, 'click', ...)\` in:

- \`frontend/src/screens/workout.js\` *(the actual culprit)*
- \`frontend/src/screens/analytics.js\`, \`dashboard.js\`, \`insights.js\`, \`nutrition.js\`, \`programs.js\`, \`learn.js\`
- \`frontend/src/features/workout-calendar.js\` *(rerenders on month nav)*
- \`frontend/src/features/nutrition/saved-meals.js\`

### 3. Belt-and-suspenders mutex on \`startWorkoutDay\`
Added a module-level \`_startingWorkout\` flag. Even if duplicate calls somehow slip through (double-click, racing async code, etc.), the second call is silently ignored until the first completes or fails.

## After this deploys
Start a workout on any day → you'll see exactly **one** AI preview → click **Start Workout** or **Skip** once → you go straight to the warmup screen.