### PR TITLE
Fix inaccurate barcode macros via robust OFF normalizer

### DIFF
--- a/src/routes/nutrition.js
+++ b/src/routes/nutrition.js
@@ -797,6 +797,204 @@ function calculateMacros(food, quantity, unit) {
   };
 }
 
+// ============================================================================
+// Open Food Facts nutrient normalization
+//
+// OFF data is notoriously inconsistent:
+//   - Some products report calories only in kJ (energy-kj_*) and need
+//     conversion (1 kcal = 4.184 kJ).
+//   - European products often report `salt` instead of `sodium`
+//     (1 g salt = 400 mg sodium).
+//   - `nutrition_data_per` tells us whether unsuffixed fields (e.g.
+//     `proteins`) are per 100 g or per serving.
+//   - Values can come in as strings.
+//   - Serving info may be absent or wildly wrong (e.g. serving_quantity = 0).
+//
+// This normalizer does its best to extract accurate per-serving macros
+// and then cross-checks calories with the Atwater formula
+// (4·P + 4·C + 9·F ≈ calories). If the declared calories disagree by
+// more than ~25%, we recompute from the macros — usually more reliable
+// than the declared energy value for low-quality OFF entries.
+// ============================================================================
+
+function toNumber(value) {
+  if (value == null || value === '') return null;
+  const n = typeof value === 'number' ? value : parseFloat(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Pick the first defined numeric value from a list of candidate field names.
+ * Returns null if none are present or all are zero/invalid — callers
+ * decide how to fall back.
+ */
+function pickNutrient(nutrients, ...fields) {
+  for (const field of fields) {
+    const val = toNumber(nutrients[field]);
+    if (val != null && val > 0) return val;
+  }
+  // If no positive value, try again but allow 0
+  for (const field of fields) {
+    const val = toNumber(nutrients[field]);
+    if (val != null) return val;
+  }
+  return null;
+}
+
+/**
+ * Resolve a per-serving value for a macronutrient using every OFF field name
+ * combination we know about. Tries, in order:
+ *   1. Direct per-serving (<name>_serving)
+ *   2. Per-100g converted by (serving_size / 100)
+ *   3. Unsuffixed field — interpreted per nutrition_data_per metadata
+ */
+function resolveMacro(nutrients, baseName, servingSize, dataBasis) {
+  const perServing = pickNutrient(nutrients, `${baseName}_serving`);
+  if (perServing != null) return perServing;
+
+  const per100 = pickNutrient(nutrients, `${baseName}_100g`);
+  if (per100 != null) {
+    return per100 * (servingSize / 100);
+  }
+
+  const unsuffixed = pickNutrient(nutrients, baseName);
+  if (unsuffixed != null) {
+    if (dataBasis === 'serving') return unsuffixed;
+    return unsuffixed * (servingSize / 100);
+  }
+  return 0;
+}
+
+/**
+ * Calories — try kcal first, then convert kJ if only kJ is available.
+ */
+function resolveCalories(nutrients, servingSize, dataBasis) {
+  const KJ_PER_KCAL = 4.184;
+
+  const kcalServing = pickNutrient(nutrients, 'energy-kcal_serving');
+  if (kcalServing != null) return kcalServing;
+
+  const kcal100 = pickNutrient(nutrients, 'energy-kcal_100g');
+  if (kcal100 != null) return kcal100 * (servingSize / 100);
+
+  const kcalBase = pickNutrient(nutrients, 'energy-kcal');
+  if (kcalBase != null) {
+    return dataBasis === 'serving' ? kcalBase : kcalBase * (servingSize / 100);
+  }
+
+  // Fall back to kJ energy fields
+  const kjServing = pickNutrient(nutrients, 'energy-kj_serving', 'energy_serving');
+  if (kjServing != null) return kjServing / KJ_PER_KCAL;
+
+  const kj100 = pickNutrient(nutrients, 'energy-kj_100g', 'energy_100g');
+  if (kj100 != null) return (kj100 / KJ_PER_KCAL) * (servingSize / 100);
+
+  const kjBase = pickNutrient(nutrients, 'energy-kj', 'energy');
+  if (kjBase != null) {
+    const kcal = kjBase / KJ_PER_KCAL;
+    return dataBasis === 'serving' ? kcal : kcal * (servingSize / 100);
+  }
+
+  return 0;
+}
+
+/**
+ * Sodium — handle both direct sodium (reported in grams) AND salt
+ * (1 g salt = 400 mg sodium) for European products.
+ */
+function resolveSodiumMg(nutrients, servingSize, dataBasis) {
+  // sodium fields are in GRAMS (per OFF conventions); convert to mg
+  const sodiumG = resolveMacro(nutrients, 'sodium', servingSize, dataBasis);
+  if (sodiumG > 0) return sodiumG * 1000;
+
+  // Fall back to salt (also in grams) — sodium = salt * 0.4
+  const saltG = resolveMacro(nutrients, 'salt', servingSize, dataBasis);
+  if (saltG > 0) return saltG * 400;
+
+  return 0;
+}
+
+function normalizeOpenFoodFactsProduct(product, barcode) {
+  const nutrients = product.nutriments || {};
+
+  // Determine whether unsuffixed fields are per-serving or per-100g.
+  // OFF uses "serving" or "100g" (default).
+  const dataBasis = product.nutrition_data_per === 'serving' ? 'serving' : '100g';
+
+  // Serving size in grams — sanity-capped to avoid absurd values.
+  let servingSize = toNumber(product.serving_quantity);
+  if (servingSize == null || servingSize <= 0 || servingSize > 5000) {
+    servingSize = 100;
+  }
+
+  const servingUnit = (product.serving_quantity_unit || 'g').toLowerCase();
+
+  // Extract macros per SERVING (our canonical unit)
+  let calories = resolveCalories(nutrients, servingSize, dataBasis);
+  const protein = Math.max(0, resolveMacro(nutrients, 'proteins', servingSize, dataBasis));
+  const carbs = Math.max(0, resolveMacro(nutrients, 'carbohydrates', servingSize, dataBasis));
+  const fat = Math.max(0, resolveMacro(nutrients, 'fat', servingSize, dataBasis));
+  const fiber = Math.max(0, resolveMacro(nutrients, 'fiber', servingSize, dataBasis));
+  const sugar = Math.max(0, resolveMacro(nutrients, 'sugars', servingSize, dataBasis));
+  const satFat = Math.max(0, resolveMacro(nutrients, 'saturated-fat', servingSize, dataBasis));
+  const sodiumMg = resolveSodiumMg(nutrients, servingSize, dataBasis);
+
+  calories = Math.max(0, calories);
+
+  // Atwater sanity check: 4·P + 4·C + 9·F should roughly equal calories.
+  // If calories is zero but macros exist, compute. If declared calories
+  // disagrees by >25% with the Atwater computation AND the product has
+  // meaningful macros, prefer the computed value (OFF's calorie field is
+  // often the worst offender on low-quality entries).
+  const atwater = protein * 4 + carbs * 4 + fat * 9;
+  if (atwater > 5) {
+    if (calories === 0) {
+      calories = atwater;
+    } else {
+      const ratio = calories / atwater;
+      if (ratio < 0.75 || ratio > 1.25) {
+        calories = atwater;
+      }
+    }
+  }
+
+  // Name / brand polishing
+  const name =
+    product.product_name ||
+    product.product_name_en ||
+    product.generic_name ||
+    product.generic_name_en ||
+    'Unknown Product';
+  const brand = product.brands ? String(product.brands).split(',')[0].trim() : null;
+
+  // Description for display
+  const servingDescription =
+    product.serving_size ||
+    (servingSize ? `${Math.round(servingSize)}${servingUnit}` : '1 serving');
+
+  return {
+    id: null,
+    name,
+    brand,
+    barcode,
+    source: 'openfoodfacts',
+    source_id: barcode,
+    serving_size: Math.round(servingSize * 10) / 10,
+    serving_unit: servingUnit === 'ml' ? 'ml' : 'g',
+    serving_description: servingDescription,
+    calories: Math.round(calories),
+    protein_g: Math.round(protein * 10) / 10,
+    carbs_g: Math.round(carbs * 10) / 10,
+    fat_g: Math.round(fat * 10) / 10,
+    fiber_g: Math.round(fiber * 10) / 10,
+    sugar_g: Math.round(sugar * 10) / 10,
+    sodium_mg: Math.round(sodiumMg),
+    saturated_fat_g: Math.round(satFat * 10) / 10,
+    verified: 1,
+    image_url: product.image_url || null
+  };
+}
+
 // Search foods in local database
 nutrition.get('/foods/search', async (c) => {
   try {
@@ -1033,10 +1231,13 @@ nutrition.get('/foods/barcode/:barcode', async (c) => {
       console.warn('Barcode cache read failed:', cacheErr.message);
     }
 
-    // Check if we already have this in our foods table
+    // Check if we have a USER-created food with this barcode (custom entries).
+    // We intentionally DO NOT return here for source='openfoodfacts' rows,
+    // because those may have been saved by the old buggy parser with wrong
+    // macros — fetching fresh from OFF and UPSERTing is safer.
     try {
       const existingFood = await db.prepare(
-        'SELECT * FROM foods WHERE barcode = ? LIMIT 1'
+        "SELECT * FROM foods WHERE barcode = ? AND source != 'openfoodfacts' LIMIT 1"
       ).bind(barcode).first();
 
       if (existingFood) {
@@ -1075,64 +1276,59 @@ nutrition.get('/foods/barcode/:barcode', async (c) => {
     }
     
     const product = data.product;
-    const nutrients = product.nutriments || {};
+    const food = normalizeOpenFoodFactsProduct(product, barcode);
     
-    // Get serving size - prefer per-serving values if available
-    const servingSize = parseFloat(product.serving_quantity) || 100;
-    const hasPerServing = nutrients['energy-kcal_serving'] !== undefined;
-    
-    // Use per-serving values if available, otherwise calculate from per-100g
-    const multiplier = hasPerServing ? 1 : (servingSize / 100);
-    
-    const food = {
-      id: null,
-      name: product.product_name || product.generic_name || 'Unknown Product',
-      brand: product.brands || null,
-      barcode: barcode,
-      source: 'openfoodfacts',
-      source_id: barcode,
-      serving_size: servingSize,
-      serving_unit: 'g',
-      serving_description: product.serving_size || `${servingSize}g`,
-      calories: hasPerServing 
-        ? (nutrients['energy-kcal_serving'] || 0)
-        : ((nutrients['energy-kcal_100g'] || nutrients['energy-kcal'] || 0) * multiplier),
-      protein_g: hasPerServing
-        ? (nutrients.proteins_serving || 0)
-        : ((nutrients.proteins_100g || nutrients.proteins || 0) * multiplier),
-      carbs_g: hasPerServing
-        ? (nutrients.carbohydrates_serving || 0)
-        : ((nutrients.carbohydrates_100g || nutrients.carbohydrates || 0) * multiplier),
-      fat_g: hasPerServing
-        ? (nutrients.fat_serving || 0)
-        : ((nutrients.fat_100g || nutrients.fat || 0) * multiplier),
-      fiber_g: hasPerServing
-        ? (nutrients.fiber_serving || 0)
-        : ((nutrients.fiber_100g || nutrients.fiber || 0) * multiplier),
-      sugar_g: hasPerServing
-        ? (nutrients.sugars_serving || 0)
-        : ((nutrients.sugars_100g || nutrients.sugars || 0) * multiplier),
-      sodium_mg: hasPerServing
-        ? ((nutrients.sodium_serving || 0) * 1000)
-        : ((nutrients.sodium_100g || 0) * 1000 * multiplier),
-      saturated_fat_g: hasPerServing
-        ? (nutrients['saturated-fat_serving'] || 0)
-        : ((nutrients['saturated-fat_100g'] || 0) * multiplier),
-      verified: 1,
-      image_url: product.image_url || null
-    };
-    
+    // UPSERT the food into our foods table so next lookup returns the
+    // freshly-normalized values (and so meal logging can reference it
+    // by id without duplicating). Uses ON CONFLICT(source, source_id).
+    let savedFood = food;
+    try {
+      const row = await db.prepare(
+        `INSERT INTO foods (
+           name, brand, barcode, source, source_id,
+           serving_size, serving_unit, serving_description,
+           calories, protein_g, carbs_g, fat_g, fiber_g, sugar_g,
+           sodium_mg, saturated_fat_g, verified
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+         ON CONFLICT(source, source_id) DO UPDATE SET
+           name = excluded.name,
+           brand = excluded.brand,
+           barcode = excluded.barcode,
+           serving_size = excluded.serving_size,
+           serving_unit = excluded.serving_unit,
+           serving_description = excluded.serving_description,
+           calories = excluded.calories,
+           protein_g = excluded.protein_g,
+           carbs_g = excluded.carbs_g,
+           fat_g = excluded.fat_g,
+           fiber_g = excluded.fiber_g,
+           sugar_g = excluded.sugar_g,
+           sodium_mg = excluded.sodium_mg,
+           saturated_fat_g = excluded.saturated_fat_g,
+           updated_at = CURRENT_TIMESTAMP
+         RETURNING *`
+      ).bind(
+        food.name, food.brand, food.barcode, food.source, food.source_id,
+        food.serving_size, food.serving_unit, food.serving_description,
+        food.calories, food.protein_g, food.carbs_g, food.fat_g,
+        food.fiber_g, food.sugar_g, food.sodium_mg, food.saturated_fat_g
+      ).first();
+      if (row) savedFood = { ...row, image_url: food.image_url };
+    } catch (upsertErr) {
+      console.warn('Food UPSERT from barcode failed:', upsertErr.message);
+    }
+
     // Cache result for 30 days (best-effort)
     try {
       await db.prepare(
         `INSERT OR REPLACE INTO barcode_cache (barcode, food_json, source, expires_at)
          VALUES (?, ?, 'openfoodfacts', datetime('now', '+30 days'))`
-      ).bind(barcode, JSON.stringify(food)).run();
+      ).bind(barcode, JSON.stringify(savedFood)).run();
     } catch (cacheErr) {
       console.warn('Barcode cache write failed:', cacheErr.message);
     }
 
-    return c.json({ food, source: 'openfoodfacts' });
+    return c.json({ food: savedFood, source: 'openfoodfacts' });
     } catch (error) {
       console.error('Open Food Facts API error:', error);
       return c.json({ food: null, error: error.message, source: 'error' });

--- a/tests/unit/off-normalizer.test.js
+++ b/tests/unit/off-normalizer.test.js
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import vm from 'node:vm';
+
+/**
+ * The OFF normalizer is defined inside src/routes/nutrition.js. To test it
+ * without importing the Hono route (which requires the Cloudflare Workers
+ * runtime), we read the file, extract the helper functions by regex, and
+ * evaluate them in an isolated context.
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(here, '../../src/routes/nutrition.js'), 'utf8');
+
+// Grab just the normalizer helpers (everything between toNumber() and the
+// closing brace of normalizeOpenFoodFactsProduct).
+function extractHelpers() {
+  const start = source.indexOf('function toNumber(');
+  const marker = 'function normalizeOpenFoodFactsProduct(';
+  const markerIdx = source.indexOf(marker, start);
+  if (start < 0 || markerIdx < 0) throw new Error('Could not locate normalizer in source');
+
+  // Find the end of normalizeOpenFoodFactsProduct by brace matching
+  let depth = 0;
+  let i = source.indexOf('{', markerIdx);
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) { i++; break; }
+    }
+  }
+  return source.slice(start, i);
+}
+
+const helpersSource = extractHelpers();
+const context = vm.createContext({ module: {}, exports: {} });
+vm.runInContext(
+  `${helpersSource}\nmodule.exports = { normalizeOpenFoodFactsProduct, resolveCalories, resolveMacro, resolveSodiumMg, toNumber };`,
+  context
+);
+const { normalizeOpenFoodFactsProduct } = context.module.exports;
+
+describe('OpenFoodFacts normalizer', () => {
+  it('uses per-serving values when available', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'Test Bar',
+      brands: 'Acme',
+      serving_quantity: 45,
+      nutriments: {
+        'energy-kcal_serving': 180,
+        'energy-kcal_100g': 400,
+        proteins_serving: 8,
+        proteins_100g: 17.8,
+        carbohydrates_serving: 22,
+        carbohydrates_100g: 48.9,
+        fat_serving: 6,
+        fat_100g: 13.3,
+        fiber_serving: 3,
+        sodium_serving: 0.15
+      }
+    }, '12345');
+
+    expect(food.calories).toBe(180);
+    expect(food.protein_g).toBe(8);
+    expect(food.carbs_g).toBe(22);
+    expect(food.fat_g).toBe(6);
+    expect(food.fiber_g).toBe(3);
+    expect(food.sodium_mg).toBe(150); // 0.15 g × 1000
+    expect(food.serving_size).toBe(45);
+    expect(food.name).toBe('Test Bar');
+    expect(food.brand).toBe('Acme');
+  });
+
+  it('converts kJ to kcal when only kJ energy is reported', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'Euro Bar',
+      serving_quantity: 40,
+      nutriments: {
+        'energy-kj_serving': 754, // ≈ 180 kcal
+        proteins_serving: 7,
+        carbohydrates_serving: 22,
+        fat_serving: 6
+      }
+    }, '44444');
+
+    // 754 kJ / 4.184 ≈ 180 kcal
+    expect(food.calories).toBeGreaterThanOrEqual(175);
+    expect(food.calories).toBeLessThanOrEqual(185);
+  });
+
+  it('converts salt to sodium when only salt is reported (EU products)', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'EU Snack',
+      serving_quantity: 30,
+      nutriments: {
+        'energy-kcal_serving': 150,
+        proteins_serving: 3,
+        carbohydrates_serving: 18,
+        fat_serving: 8,
+        salt_serving: 0.5 // 0.5 g salt → 200 mg sodium
+      }
+    }, '55555');
+
+    expect(food.sodium_mg).toBe(200);
+  });
+
+  it('scales per-100g values to the reported serving size', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'Pasta',
+      serving_quantity: 75,
+      nutriments: {
+        'energy-kcal_100g': 360,
+        proteins_100g: 12,
+        carbohydrates_100g: 72,
+        fat_100g: 2
+      }
+    }, '66666');
+
+    // 75g serving = 0.75 × per-100g values
+    expect(food.calories).toBe(270); // 360 × 0.75 = 270
+    expect(food.protein_g).toBe(9);  // 12 × 0.75 = 9
+    expect(food.carbs_g).toBe(54);   // 72 × 0.75 = 54
+    expect(food.fat_g).toBeCloseTo(1.5, 1);
+  });
+
+  it('falls back to 100g when serving_quantity is missing or absurd', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'No Serving',
+      nutriments: {
+        'energy-kcal_100g': 250,
+        proteins_100g: 10,
+        carbohydrates_100g: 30,
+        fat_100g: 10
+      }
+    }, '77777');
+
+    expect(food.serving_size).toBe(100);
+    expect(food.calories).toBe(250);
+  });
+
+  it('recomputes calories via Atwater when declared value is way off', () => {
+    // Declared calories say 50 but macros imply ~200 kcal
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'Mislabeled',
+      serving_quantity: 100,
+      nutriments: {
+        'energy-kcal_serving': 50, // WRONG
+        proteins_serving: 10,      // 40 kcal
+        carbohydrates_serving: 20, // 80 kcal
+        fat_serving: 10            // 90 kcal → total 210 kcal
+      }
+    }, '88888');
+
+    // Declared 50 / Atwater 210 = 0.24 ratio (way outside ±25%)
+    // Should be corrected to the Atwater value
+    expect(food.calories).toBe(210);
+  });
+
+  it('computes calories from macros when energy field is missing entirely', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'No Calories Field',
+      serving_quantity: 100,
+      nutriments: {
+        proteins_serving: 20,
+        carbohydrates_serving: 30,
+        fat_serving: 10
+      }
+    }, '99999');
+
+    // 20×4 + 30×4 + 10×9 = 80 + 120 + 90 = 290
+    expect(food.calories).toBe(290);
+  });
+
+  it('handles string numeric values from OFF', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'String values',
+      serving_quantity: '50',
+      nutriments: {
+        'energy-kcal_serving': '180',
+        proteins_serving: '7.5',
+        carbohydrates_serving: '22',
+        fat_serving: '6'
+      }
+    }, '11111');
+
+    expect(food.calories).toBe(180);
+    expect(food.protein_g).toBe(7.5);
+  });
+
+  it('uses nutrition_data_per=serving when unsuffixed fields are per-serving', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'Per-serving default',
+      serving_quantity: 50,
+      nutrition_data_per: 'serving',
+      nutriments: {
+        'energy-kcal': 200,
+        proteins: 10,
+        carbohydrates: 20,
+        fat: 8
+      }
+    }, '22222');
+
+    // Since data_per is 'serving', unsuffixed fields are used directly
+    expect(food.calories).toBe(200);
+    expect(food.protein_g).toBe(10);
+  });
+
+  it('uses nutrition_data_per=100g as default when unsuffixed fields are per-100g', () => {
+    const food = normalizeOpenFoodFactsProduct({
+      product_name: 'Per-100g default',
+      serving_quantity: 50,
+      // nutrition_data_per omitted or '100g'
+      nutriments: {
+        'energy-kcal': 400,
+        proteins: 20,
+        carbohydrates: 40,
+        fat: 16
+      }
+    }, '33333');
+
+    // 50g serving, per-100g values → 0.5 × each
+    expect(food.calories).toBe(200);
+    expect(food.protein_g).toBe(10);
+  });
+});


### PR DESCRIPTION
## Bug
Typing in a barcode returned macros that didn't match the product label.

## Root causes (seven of them)
Open Food Facts data is inconsistent in several ways the old parser didn't handle:

1. **Missing kcal, only kJ** — European products often only report `energy-kj_*`. Old code returned 0 calories.
2. **Salt not sodium** — EU products often report `salt` instead of `sodium` (1 g salt = 400 mg sodium). Old code returned 0 sodium.
3. **Ambiguous unsuffixed fields** — `nutrition_data_per` tells whether unsuffixed fields (`proteins`, `fat`) are per-serving or per-100g. Old code always assumed per-100g.
4. **Bad declared calories** — some OFF entries have energy values that disagree with their macros by 2× or more. Old code trusted them blindly.
5. **String numeric values** — OFF sometimes returns numbers as strings. Old code's `|| 0` fallback didn't coerce.
6. **Zero/absurd serving_quantity** — some entries have `serving_quantity: 0` or values over 5 kg. Old code divided by zero or produced nonsense.
7. **Stale local-table rows** — the endpoint checked the `foods` table before OFF. Any barcode already saved by the old buggy parser returned wrong data forever.

## Fix
New `normalizeOpenFoodFactsProduct()` helper with layered fallbacks:

- **Calories**: kcal fields → kJ ÷ 4.184 → Atwater (`4P + 4C + 9F`) if all missing
- **Macros**: per-serving → per-100g × (serving/100) → unsuffixed interpreted via `nutrition_data_per`
- **Sodium**: sodium (g→mg ×1000) → salt (g→mg ×400)
- **Atwater validation**: if declared cal differs from `4P + 4C + 9F` by >±25% (and macros have real values), recompute from macros
- **Guards**: clamp `serving_size` to 100 g if missing/zero/>5 kg; coerce all nutrient values through `parseFloat`

### Stale-data fixes
- Local-table shortcut now only returns **non-OpenFoodFacts** rows (user-created foods). OFF barcodes always re-fetch.
- After a successful OFF fetch, UPSERT into `foods` via `ON CONFLICT(source, source_id) DO UPDATE` — existing rows get macros corrected in place.
- Cleared remote `barcode_cache` manually so the next lookup of any barcode is fresh.

## Tests
**+10 new unit tests** in `tests/unit/off-normalizer.test.js` covering per-serving vs per-100g selection, kJ→kcal, salt→sodium, serving scaling, serving-size fallback, Atwater correction, Atwater fallback, string coercion, and `nutrition_data_per` handling.

99 tests total, all passing.