### PR TITLE
Tailored in-workout AI + Cloudflare AI Gateway + cross-browser barcode scanner

### DIFF
--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -2053,6 +2053,41 @@
 
 .live-coach-actions .btn { flex: 1; }
 
+/* Richer context panel for the live AI coach */
+.live-coach-context {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: 0 var(--space-4) var(--space-3);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-2);
+}
+
+.live-coach-context-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px var(--space-2);
+  background: var(--color-surface-sunken);
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.live-coach-source {
+  margin-left: var(--space-2);
+  padding: 1px var(--space-2);
+  font-size: 9px;
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  border-radius: var(--radius-full);
+  vertical-align: middle;
+}
+
 /* ---------- Workout Tab ---------- */
 .workout-hero {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -3001,6 +3036,19 @@
   border-radius: var(--radius-full);
   pointer-events: none;
   white-space: nowrap;
+}
+
+.barcode-scanner-engine {
+  position: absolute;
+  bottom: var(--space-2);
+  right: var(--space-2);
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  font-size: 10px;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-full);
+  pointer-events: none;
+  opacity: 0.8;
 }
 
 .barcode-frame {

--- a/frontend/src/features/active-workout/controller.js
+++ b/frontend/src/features/active-workout/controller.js
@@ -492,10 +492,14 @@ async function logSet(exerciseId) {
     });
     showRestTimer();
 
-    // AI coach analysis
+    // AI coach analysis — pass exercise_id + workout_id so the backend
+    // can fetch the user's history for this exercise and tailor the tip.
     if (window.aiCoach?.analyzeSet && refreshedExercise) {
       const parsedTargetReps = parseInt(String(refreshedExercise.target_reps || '10').split(/[-–]/)[0], 10) || 10;
+      const currentWorkout = getWorkout();
       window.aiCoach.analyzeSet({
+        exerciseId: refreshedExercise.exercise_id || refreshedExercise.id,
+        workoutId: currentWorkout?.id,
         currentSets: refreshedExercise.sets || [],
         targetReps: parsedTargetReps,
         targetSets: refreshedExercise.target_sets || 3

--- a/frontend/src/features/ai-coach/LiveCoachOverlay.js
+++ b/frontend/src/features/ai-coach/LiveCoachOverlay.js
@@ -21,12 +21,52 @@ let currentTip = null;
 let onActionCallback = null;
 
 const TIP_ICONS = {
+  thinking: { icon: 'fa-brain fa-beat', color: 'var(--color-primary)', title: 'Coach analyzing…' },
   progression: { icon: 'fa-arrow-up', color: 'var(--color-secondary)', title: 'Great progress!' },
   on_track: { icon: 'fa-check-circle', color: 'var(--color-primary)', title: 'On target' },
   complete: { icon: 'fa-trophy', color: 'var(--color-gold)', title: 'Crushed it!' },
   form_warning: { icon: 'fa-exclamation-triangle', color: 'var(--color-warning)', title: 'Form watch' },
-  load_warning: { icon: 'fa-weight-hanging', color: 'var(--color-warning)', title: 'Weight watch' }
+  load_warning: { icon: 'fa-weight-hanging', color: 'var(--color-warning)', title: 'Weight watch' },
+  pr_attempt: { icon: 'fa-medal', color: 'var(--color-gold)', title: 'New PR attempt' },
+  context: { icon: 'fa-robot', color: 'var(--color-primary)', title: 'AI Coach' },
+  context_only: { icon: 'fa-robot', color: 'var(--color-primary)', title: 'AI Coach' }
 };
+
+function renderContextPanel(context) {
+  if (!context) return '';
+
+  const parts = [];
+  if (context.trend?.state && context.trend.state !== 'insufficient data') {
+    const trendColor =
+      context.trend.state === 'progressing' ? 'var(--color-secondary)' :
+      context.trend.state === 'regressing' || context.trend.state === 'stalled' ? 'var(--color-warning)' :
+      'var(--color-text-muted)';
+    parts.push(html`
+      <span class="live-coach-context-chip" style="color: ${trendColor};">
+        <i class="fas fa-chart-line"></i>
+        ${context.trend.state}${context.trend.detail ? ` · ${context.trend.detail}` : ''}
+      </span>
+    `);
+  }
+  if (context.personal_records?.max_weight_kg > 0) {
+    parts.push(html`
+      <span class="live-coach-context-chip">
+        <i class="fas fa-trophy"></i>
+        PR ${context.personal_records.max_weight_kg}kg
+      </span>
+    `);
+  }
+  if (context.is_attempting_pr) {
+    parts.push(html`
+      <span class="live-coach-context-chip" style="color: var(--color-gold);">
+        <i class="fas fa-star"></i> PR attempt!
+      </span>
+    `);
+  }
+
+  if (parts.length === 0) return '';
+  return html`<div class="live-coach-context">${parts}</div>`;
+}
 
 function renderOverlay() {
   if (!currentTip) {
@@ -50,25 +90,34 @@ function renderOverlay() {
     `;
   }
 
-  const meta = TIP_ICONS[currentTip.type] || TIP_ICONS.on_track;
+  const meta = TIP_ICONS[currentTip.type] || TIP_ICONS.context;
+  const isThinking = currentTip.type === 'thinking';
+  const sourceLabel = currentTip.source === 'ai'
+    ? html`<span class="live-coach-source">AI · tailored</span>`
+    : currentTip.source === 'rules'
+    ? html`<span class="live-coach-source">rules</span>`
+    : '';
 
   return html`
     <div class="live-coach-overlay has-tip ${collapsed ? 'is-collapsed' : ''}" role="status">
       <button class="live-coach-toggle" data-action="toggle">
         <div class="live-coach-avatar" style="color: ${meta.color};">
           <i class="fas ${meta.icon}"></i>
-          <span class="live-coach-pulse"></span>
+          ${!isThinking ? html`<span class="live-coach-pulse"></span>` : ''}
         </div>
         ${collapsed
           ? html`<div class="live-coach-subtitle">${meta.title}</div>`
           : html`
               <div class="live-coach-body">
-                <div class="live-coach-title">${meta.title}</div>
+                <div class="live-coach-title">
+                  ${meta.title}${sourceLabel}
+                </div>
                 <div class="live-coach-subtitle">${currentTip.message}</div>
               </div>
             `}
         <i class="fas ${collapsed ? 'fa-chevron-up' : 'fa-chevron-down'} live-coach-chevron"></i>
       </button>
+      ${!collapsed && !isThinking ? renderContextPanel(currentTip.context) : ''}
       ${!collapsed && currentTip.action
         ? html`
             <div class="live-coach-actions">
@@ -150,6 +199,8 @@ export function destroyLiveCoach() {
  * Analyze a set that was just logged and surface a tip if applicable.
  *
  * @param {object} params
+ * @param {number} [params.exerciseId] - enables tailored (history-aware) coaching
+ * @param {number} [params.workoutId]  - current workout id (excluded from history lookup)
  * @param {Array<{weight_kg:number, reps:number}>} params.currentSets
  * @param {number} params.targetReps
  * @param {number} params.targetSets
@@ -157,8 +208,16 @@ export function destroyLiveCoach() {
 export async function analyzeSet(params) {
   if (!overlayEl) return;
 
+  // Show "thinking" state so the user knows something is happening during
+  // the AI round-trip (can be 1-3s for the 8B model)
+  currentTip = { type: 'thinking', message: 'Coach is analyzing your set…' };
+  collapsed = false;
+  updateOverlay();
+
   try {
     const response = await api.post('/ai/realtime/analyze', {
+      exercise_id: params.exerciseId || null,
+      workout_id: params.workoutId || null,
       current_sets: params.currentSets,
       target_reps: params.targetReps,
       target_sets: params.targetSets
@@ -166,24 +225,32 @@ export async function analyzeSet(params) {
 
     if (response.insight) {
       currentTip = response.insight;
-      collapsed = false; // auto-expand for new tips
       updateOverlay();
 
-      // Auto-hide routine-status tips after 8s; keep warnings
-      if (!response.insight.action && response.insight.type !== 'form_warning' && response.insight.type !== 'load_warning') {
+      // Auto-hide routine-status tips after 10s; keep warnings and PR
+      // attempts visible until user dismisses.
+      const sticky = ['form_warning', 'load_warning', 'pr_attempt'];
+      const hasAction = !!response.insight.action;
+      if (!hasAction && !sticky.includes(response.insight.type)) {
         setTimeout(() => {
           if (currentTip === response.insight) {
             currentTip = null;
             updateOverlay();
           }
-        }, 8000);
+        }, 10000);
       }
 
       events.emit('aiCoach:tip', response.insight);
+    } else {
+      // No insight to show — clear the thinking bubble
+      currentTip = null;
+      updateOverlay();
     }
   } catch (err) {
     // Silent failure — the AI coach is nice-to-have, not critical
     console.warn('AI coach analysis failed:', err);
+    currentTip = null;
+    updateOverlay();
   }
 }
 

--- a/frontend/src/features/nutrition/barcode-decoder.js
+++ b/frontend/src/features/nutrition/barcode-decoder.js
@@ -1,0 +1,158 @@
+/**
+ * Cross-browser barcode decoder.
+ *
+ * Strategy:
+ *   1. Native BarcodeDetector — Chrome / Edge / Android (instant, no deps)
+ *   2. ZXing-js fallback loaded from CDN on-demand — Safari / Firefox / iOS
+ *
+ * The ZXing bundle is ~100 KB gzipped so we load it dynamically only when
+ * the native API is missing AND the user actually opens the scanner. This
+ * keeps the first-paint bundle small for the 90% of Chrome users who get
+ * the native path.
+ *
+ * Public API:
+ *   const decoder = createDecoder();
+ *   await decoder.start(videoElement, onResult);   // returns when first code found
+ *   decoder.stop();
+ */
+
+const SUPPORTED_FORMATS = ['ean_13', 'ean_8', 'upc_a', 'upc_e', 'code_128', 'code_39'];
+
+// ZXing CDN — pinned to a specific version for reproducibility
+const ZXING_CDN = 'https://cdn.jsdelivr.net/npm/@zxing/browser@0.1.5/+esm';
+
+let zxingModulePromise = null;
+
+async function loadZXing() {
+  if (!zxingModulePromise) {
+    // Use a dynamic import with a non-literal URL so Vite doesn't try to
+    // resolve it at build time
+    zxingModulePromise = import(/* @vite-ignore */ ZXING_CDN)
+      .catch((err) => {
+        zxingModulePromise = null; // allow retry
+        throw err;
+      });
+  }
+  return zxingModulePromise;
+}
+
+export function hasNativeDetector() {
+  return typeof window !== 'undefined' && 'BarcodeDetector' in window;
+}
+
+export function hasCameraSupport() {
+  return typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia;
+}
+
+/**
+ * Create a decoder instance. Call `.start(videoEl, onResult)` to begin
+ * and `.stop()` to release resources.
+ */
+export function createDecoder() {
+  let stream = null;
+  let active = false;
+  let zxingControls = null;
+  let rafHandle = null;
+
+  async function start(videoEl, onResult, onError) {
+    if (!hasCameraSupport()) {
+      onError?.(new Error('camera-unsupported'));
+      return;
+    }
+
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: 'environment' } }
+      });
+    } catch (err) {
+      onError?.(err);
+      return;
+    }
+
+    videoEl.srcObject = stream;
+    try {
+      await videoEl.play();
+    } catch {
+      // Autoplay may be blocked on iOS until user taps the video
+    }
+    active = true;
+
+    // Route 1: native BarcodeDetector (fastest, Chrome/Edge/Android)
+    if (hasNativeDetector()) {
+      try {
+        const detector = new window.BarcodeDetector({ formats: SUPPORTED_FORMATS });
+        runNativeLoop(videoEl, detector, onResult);
+        return;
+      } catch (err) {
+        // Some Chrome builds report BarcodeDetector but throw on construction.
+        // Fall through to ZXing.
+        console.warn('Native BarcodeDetector construction failed, falling back to ZXing:', err);
+      }
+    }
+
+    // Route 2: ZXing-js fallback (Safari / Firefox / iOS / WebView)
+    try {
+      const zxing = await loadZXing();
+      const { BrowserMultiFormatReader } = zxing;
+      const reader = new BrowserMultiFormatReader();
+      zxingControls = await reader.decodeFromVideoElement(videoEl, (result, err) => {
+        if (!active || !result) return;
+        try {
+          const barcode = result.getText ? result.getText() : String(result);
+          if (barcode) {
+            onResult(barcode);
+          }
+        } catch (innerErr) {
+          console.warn('ZXing result parse failed:', innerErr);
+        }
+      });
+    } catch (err) {
+      console.error('ZXing load failed:', err);
+      onError?.(err);
+    }
+  }
+
+  function runNativeLoop(videoEl, detector, onResult) {
+    const tick = async () => {
+      if (!active || !videoEl.isConnected) return;
+      if (videoEl.readyState < 2 || !videoEl.videoWidth) {
+        rafHandle = requestAnimationFrame(tick);
+        return;
+      }
+      try {
+        const codes = await detector.detect(videoEl);
+        if (codes.length > 0) {
+          const barcode = codes[0].rawValue;
+          if (barcode) {
+            onResult(barcode);
+            return;
+          }
+        }
+      } catch {
+        // Transient detection error — just try again next frame
+      }
+      rafHandle = requestAnimationFrame(tick);
+    };
+    tick();
+  }
+
+  function stop() {
+    active = false;
+    if (rafHandle) {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = null;
+    }
+    if (zxingControls) {
+      try {
+        zxingControls.stop();
+      } catch {}
+      zxingControls = null;
+    }
+    if (stream) {
+      stream.getTracks().forEach((t) => t.stop());
+      stream = null;
+    }
+  }
+
+  return { start, stop };
+}

--- a/frontend/src/features/nutrition/meal-logger.js
+++ b/frontend/src/features/nutrition/meal-logger.js
@@ -7,6 +7,7 @@ import { html, raw } from '@core/html';
 import { api } from '@core/api';
 import { openModal, closeTopModal } from '@ui/Modal';
 import { toast } from '@ui/Toast';
+import { createDecoder, hasCameraSupport, hasNativeDetector } from './barcode-decoder.js';
 
 let state = {
   mealType: 'snack',
@@ -15,6 +16,7 @@ let state = {
   scannedFood: null,
   scannerStream: null,
   scannerActive: false,
+  scannerDecoder: null,
   searchDebounce: null
 };
 
@@ -26,6 +28,7 @@ function resetState() {
     scannedFood: null,
     scannerStream: null,
     scannerActive: false,
+    scannerDecoder: null,
     searchDebounce: null
   };
 }
@@ -371,20 +374,16 @@ async function saveMeal() {
 // ============================================================================
 
 export function showBarcodeScanner() {
-  // Feature detection upfront so we can show an honest message. The native
-  // BarcodeDetector API is only available in Chrome/Edge (desktop + Android);
-  // iOS Safari and Firefox don't support it. Without it, auto-detect can't
-  // work, so we fall back to manual entry immediately.
-  const hasCamera = !!navigator.mediaDevices?.getUserMedia;
-  const hasDetector = typeof window !== 'undefined' && 'BarcodeDetector' in window;
-  const canAutoScan = hasCamera && hasDetector;
+  const hasCamera = hasCameraSupport();
+  // Engine label shown in the status bar so users know which path is running
+  const engineLabel = hasNativeDetector() ? 'Native scanner' : 'ZXing fallback';
 
   openModal({
     title: 'Scan Barcode',
     size: 'default',
     content: String(html`
       <div class="barcode-scanner-layout">
-        ${canAutoScan
+        ${hasCamera
           ? html`
               <div id="barcode-scanner-container" class="barcode-scanner-container">
                 <video id="barcode-video" playsinline muted autoplay></video>
@@ -392,6 +391,7 @@ export function showBarcodeScanner() {
                 <div id="barcode-scanner-status" class="barcode-scanner-status">
                   <i class="fas fa-circle-notch fa-spin"></i> Starting camera…
                 </div>
+                <div class="barcode-scanner-engine">${engineLabel}</div>
               </div>
               <p class="text-muted" style="font-size: var(--text-sm); text-align: center; margin: 0;">
                 Point your camera at a UPC / EAN barcode.
@@ -400,11 +400,9 @@ export function showBarcodeScanner() {
           : html`
               <div class="card card-sunken" style="text-align: center; padding: var(--space-5);">
                 <div style="font-size: 40px; margin-bottom: var(--space-2);">📷</div>
-                <strong>Auto-scan unavailable</strong>
+                <strong>Camera not available</strong>
                 <p class="text-muted" style="font-size: var(--text-sm); margin-top: var(--space-2);">
-                  ${!hasCamera
-                    ? 'Camera access is not available in this browser.'
-                    : 'This browser does not support barcode auto-detection. Use manual entry below, or try Chrome or Edge.'}
+                  This browser does not support camera access. Use manual entry below.
                 </p>
               </div>
             `}
@@ -426,7 +424,7 @@ export function showBarcodeScanner() {
     `),
     actions: [{ label: 'Close', variant: 'btn-outline' }],
     onOpen: ({ element }) => {
-      if (canAutoScan) startBarcodeScanner();
+      if (hasCamera) startBarcodeScanner();
 
       const input = element.querySelector('#manual-barcode');
       input?.focus();
@@ -457,77 +455,74 @@ function setScannerStatus(text, spinner = false) {
 async function startBarcodeScanner() {
   const video = document.getElementById('barcode-video');
   const container = document.getElementById('barcode-scanner-container');
-  if (!video || !navigator.mediaDevices?.getUserMedia) return;
+  if (!video) return;
 
-  setScannerStatus('Requesting camera…', true);
+  setScannerStatus('Starting camera…', true);
 
-  try {
-    const stream = await navigator.mediaDevices.getUserMedia({
-      video: { facingMode: { ideal: 'environment' } }
-    });
-    video.srcObject = stream;
-    // iOS + some other browsers require play() to be awaited
-    try {
-      await video.play();
-    } catch {
-      // Autoplay may be blocked — user can tap the video to start
-    }
-    state.scannerStream = stream;
-    state.scannerActive = true;
-
-    if ('BarcodeDetector' in window) {
-      setScannerStatus('Looking for a barcode…', true);
-      const detector = new window.BarcodeDetector({
-        formats: ['ean_13', 'ean_8', 'upc_a', 'upc_e', 'code_128', 'code_39']
-      });
-      detectLoop(video, detector);
-    } else {
-      setScannerStatus('Scanner unavailable — use manual entry below', false);
-    }
-  } catch (err) {
-    console.warn('Camera access failed:', err);
-    if (container) {
-      container.innerHTML = String(html`
-        <div style="text-align: center; padding: var(--space-5);">
-          <div style="font-size: 40px;">📷</div>
-          <strong>Camera blocked</strong>
-          <p class="text-muted" style="font-size: var(--text-sm); margin-top: var(--space-2);">
-            ${err.name === 'NotAllowedError'
-              ? 'Please grant camera access or use manual entry below.'
-              : 'Camera unavailable — use manual entry below.'}
-          </p>
-        </div>
-      `);
-    }
+  // Dispose any prior decoder instance (e.g. if the modal was reopened quickly)
+  if (state.scannerDecoder) {
+    try { state.scannerDecoder.stop(); } catch {}
   }
-}
 
-async function detectLoop(video, detector) {
-  if (!state.scannerActive || !video.srcObject || !document.body.contains(video)) return;
-  if (video.readyState < 2 || !video.videoWidth) {
-    setTimeout(() => detectLoop(video, detector), 100);
-    return;
-  }
-  try {
-    const codes = await detector.detect(video);
-    if (codes.length > 0) {
-      const barcode = codes[0].rawValue;
-      stopBarcodeScanner();
-      const input = document.getElementById('manual-barcode');
-      if (input) input.value = barcode;
-      await lookupBarcode();
-      return;
+  const decoder = createDecoder();
+  state.scannerDecoder = decoder;
+  state.scannerActive = true;
+
+  const handleResult = async (barcode) => {
+    if (!state.scannerActive) return;
+    state.scannerActive = false;
+    decoder.stop();
+    state.scannerDecoder = null;
+    setScannerStatus(`Found: ${barcode}`, false);
+
+    const input = document.getElementById('manual-barcode');
+    if (input) input.value = barcode;
+    await lookupBarcode();
+  };
+
+  const handleError = (err) => {
+    console.warn('Scanner error:', err);
+    state.scannerActive = false;
+    if (!container) return;
+
+    const code = err?.name || err?.message;
+    let message = 'Camera unavailable — use manual entry below.';
+    if (code === 'NotAllowedError' || code === 'PermissionDeniedError') {
+      message = 'Camera access was denied. Enable permissions or use manual entry below.';
+    } else if (code === 'NotFoundError' || code === 'DevicesNotFoundError') {
+      message = 'No camera found on this device. Use manual entry below.';
+    } else if (code === 'camera-unsupported') {
+      message = 'This browser does not expose the camera API. Use manual entry below.';
     }
-  } catch {
-    // ignore
+
+    container.innerHTML = String(html`
+      <div style="text-align: center; padding: var(--space-5);">
+        <div style="font-size: 40px;">📷</div>
+        <strong>Camera blocked</strong>
+        <p class="text-muted" style="font-size: var(--text-sm); margin-top: var(--space-2);">${message}</p>
+      </div>
+    `);
+  };
+
+  await decoder.start(video, handleResult, handleError);
+
+  // If we're still active + no error happened, the engine is running
+  if (state.scannerActive) {
+    setScannerStatus('Looking for a barcode…', true);
   }
-  if (state.scannerActive) setTimeout(() => detectLoop(video, detector), 100);
 }
 
 function stopBarcodeScanner() {
   state.scannerActive = false;
-  state.scannerStream?.getTracks().forEach((t) => t.stop());
-  state.scannerStream = null;
+  if (state.scannerDecoder) {
+    try { state.scannerDecoder.stop(); } catch {}
+    state.scannerDecoder = null;
+  }
+  // Legacy stream cleanup for backward compat
+  if (state.scannerStream) {
+    state.scannerStream.getTracks?.().forEach((t) => t.stop());
+    state.scannerStream = null;
+  }
 }
 
 async function lookupBarcode() {

--- a/src/routes/ai.js
+++ b/src/routes/ai.js
@@ -9,7 +9,8 @@ import {
 import {
   buildPreWorkoutContext,
   predictNextSet,
-  analyzePostSet
+  analyzePostSet,
+  analyzeSetWithContext
 } from '../services/ai-realtime.js';
 import {
   analyzeNutrition,
@@ -345,7 +346,7 @@ ai.post('/coach/generate', async (c) => {
   }
 
   try {
-    const result = await generateCoachingAnalysis(db, aiModel, user.id, analysisType);
+    const result = await generateCoachingAnalysis(db, aiModel, user.id, analysisType, c.env);
     return c.json(result);
   } catch (error) {
     console.error('Error generating coaching analysis:', error);
@@ -361,7 +362,7 @@ ai.get('/coach/exercise/:exerciseId', async (c) => {
   const exerciseId = c.req.param('exerciseId');
 
   try {
-    const result = await getExerciseCoaching(db, aiModel, user.id, exerciseId);
+    const result = await getExerciseCoaching(db, aiModel, user.id, exerciseId, c.env);
     return c.json(result);
   } catch (error) {
     console.error('Error getting exercise coaching:', error);
@@ -383,7 +384,7 @@ ai.post('/coach/chat', async (c) => {
       return c.json({ error: 'Message is required' }, 400);
     }
 
-    const result = await chatWithCoach(db, aiModel, user.id, message, history);
+    const result = await chatWithCoach(db, aiModel, user.id, message, history, c.env);
     
     // Save conversation to database if successful
     if (result.success) {
@@ -532,17 +533,32 @@ ai.get('/realtime/predict/:exerciseId', async (c) => {
 });
 
 /**
- * Post-set analysis: suggest rest-time adjustments, form warnings, progression cues.
+ * Post-set analysis: personalized mid-workout coaching that references the
+ * user's actual exercise history, PRs, recent training load, and current
+ * workout trend. AI-powered with a rule-based fallback.
  *
  * POST /api/ai/realtime/analyze
- * Body: { current_sets: [{weight_kg, reps}, ...], target_reps, target_sets }
+ * Body: {
+ *   exercise_id?: number,       // required for tailored insights
+ *   workout_id?: number,        // current workout id (excluded from history)
+ *   current_sets: [{weight_kg, reps}, ...],
+ *   target_reps: number,
+ *   target_sets: number
+ * }
  */
 ai.post('/realtime/analyze', async (c) => {
-  requireAuth(c);
+  const user = requireAuth(c);
+  const db = c.env.DB;
 
   try {
     const body = await c.req.json();
-    const insight = analyzePostSet({
+    const insight = await analyzeSetWithContext({
+      ai: c.env.AI,
+      env: c.env,
+      db,
+      user,
+      exerciseId: body.exercise_id ? Number(body.exercise_id) : null,
+      workoutId: body.workout_id ? Number(body.workout_id) : null,
       currentSets: body.current_sets || [],
       targetReps: body.target_reps || 10,
       targetSets: body.target_sets || 3
@@ -550,7 +566,13 @@ ai.post('/realtime/analyze', async (c) => {
     return c.json({ success: true, insight });
   } catch (error) {
     console.error('Post-set analysis error:', error);
-    return c.json({ error: error.message }, 500);
+    // Graceful fallback: never 500 — fall back to pure rule-based
+    const fallback = analyzePostSet({
+      currentSets: (await c.req.json().catch(() => ({})))?.current_sets || [],
+      targetReps: 10,
+      targetSets: 3
+    });
+    return c.json({ success: false, error: error.message, insight: fallback });
   }
 });
 
@@ -570,7 +592,7 @@ ai.get('/nutrition/analyze', async (c) => {
   const date = c.req.query('date');
 
   try {
-    const result = await analyzeNutrition({ ai: c.env.AI, db, user, date });
+    const result = await analyzeNutrition({ ai: c.env.AI, db, user, date, env: c.env });
     return c.json({ success: true, ...result });
   } catch (error) {
     console.error('AI nutrition analyze error:', error);
@@ -601,7 +623,8 @@ ai.post('/nutrition/suggest-meal', async (c) => {
       ai: c.env.AI,
       db,
       user,
-      mealType: body?.meal_type || 'next'
+      mealType: body?.meal_type || 'next',
+      env: c.env
     });
     return c.json({ success: true, ...result });
   } catch (error) {
@@ -617,7 +640,7 @@ ai.post('/nutrition/suggest-meal', async (c) => {
  * Body: { text: "2 eggs and a banana" }
  */
 ai.post('/nutrition/parse-meal', async (c) => {
-  requireAuth(c);
+  const user = requireAuth(c);
 
   let body = {};
   try {
@@ -629,7 +652,9 @@ ai.post('/nutrition/parse-meal', async (c) => {
   try {
     const result = await parseMealFromText({
       ai: c.env.AI,
-      text: body?.text || ''
+      text: body?.text || '',
+      env: c.env,
+      userId: user.id
     });
     return c.json({ success: true, ...result });
   } catch (error) {

--- a/src/services/ai-coach.js
+++ b/src/services/ai-coach.js
@@ -3,6 +3,25 @@
  * Provides intelligent, personalized recommendations based on complete workout history
  */
 
+import { buildGatewayOptions } from '../utils/ai-parser.js';
+
+/**
+ * Helper to call env.AI.run() with gateway options when available.
+ * All AI calls in this service should go through this wrapper so they
+ * benefit from gateway logging + caching when AI_GATEWAY_ID is set.
+ */
+function withGateway(ai, model, inputs, env, featureName, userId, overrides = {}) {
+  const options = {};
+  const gateway = env ? buildGatewayOptions(env, {
+    metadata: { feature: featureName, userId: String(userId || 'unknown') },
+    ...overrides
+  }) : null;
+  if (gateway) options.gateway = gateway;
+  return Object.keys(options).length > 0
+    ? ai.run(model, inputs, options)
+    : ai.run(model, inputs);
+}
+
 /**
  * Aggregate comprehensive user training data for AI analysis
  */
@@ -338,7 +357,7 @@ Based on this comprehensive training data, provide your expert coaching analysis
 /**
  * Generate AI coaching analysis
  */
-export async function generateCoachingAnalysis(db, ai, userId, analysisType = 'comprehensive') {
+export async function generateCoachingAnalysis(db, ai, userId, analysisType = 'comprehensive', env = null) {
   // Aggregate all training data
   const trainingData = await aggregateTrainingData(db, userId, { days: 90 });
   
@@ -422,13 +441,21 @@ Based on their recent training, provide pre-workout guidance in JSON format:
 
   try {
     // Call AI model
-    const response = await ai.run('@cf/meta/llama-3.1-8b-instruct', {
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: fullPrompt }
-      ],
-      max_tokens: 2000
-    });
+    const response = await withGateway(
+      ai,
+      '@cf/meta/llama-3.1-8b-instruct',
+      {
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: fullPrompt }
+        ],
+        max_tokens: 2000
+      },
+      env,
+      `coach_analysis_${analysisType}`,
+      userId,
+      { cacheTtl: 300 }
+    );
 
     // Parse response
     let analysis = null;
@@ -469,7 +496,7 @@ Based on their recent training, provide pre-workout guidance in JSON format:
 /**
  * Generate exercise-specific coaching
  */
-export async function getExerciseCoaching(db, ai, userId, exerciseId) {
+export async function getExerciseCoaching(db, ai, userId, exerciseId, env = null) {
   // Get exercise details
   const exercise = await db.prepare(`
     SELECT * FROM exercises WHERE id = ?
@@ -549,12 +576,20 @@ Provide coaching in JSON format:
 }`;
 
   try {
-    const response = await ai.run('@cf/meta/llama-3.1-8b-instruct', {
-      messages: [
-        { role: 'system', content: 'You are an expert strength coach specializing in exercise programming and technique.' },
-        { role: 'user', content: prompt }
-      ]
-    });
+    const response = await withGateway(
+      ai,
+      '@cf/meta/llama-3.1-8b-instruct',
+      {
+        messages: [
+          { role: 'system', content: 'You are an expert strength coach specializing in exercise programming and technique.' },
+          { role: 'user', content: prompt }
+        ]
+      },
+      env,
+      'exercise_coaching',
+      userId,
+      { cacheTtl: 1800 }
+    );
 
     let coaching = null;
     try {
@@ -585,7 +620,7 @@ Provide coaching in JSON format:
 /**
  * AI Chat - Ask the coach anything
  */
-export async function chatWithCoach(db, ai, userId, message, conversationHistory = []) {
+export async function chatWithCoach(db, ai, userId, message, conversationHistory = [], env = null) {
   // Get comprehensive user context (90 days for better analysis)
   const trainingData = await aggregateTrainingData(db, userId, { days: 90 });
   
@@ -675,10 +710,18 @@ YOUR COACHING GUIDELINES:
   ];
 
   try {
-    const response = await ai.run('@cf/meta/llama-3.1-8b-instruct', {
-      messages,
-      max_tokens: 1500
-    });
+    const response = await withGateway(
+      ai,
+      '@cf/meta/llama-3.1-8b-instruct',
+      {
+        messages,
+        max_tokens: 1500
+      },
+      env,
+      'coach_chat',
+      userId,
+      { cacheTtl: 0, skipCache: true }
+    );
 
     return {
       success: true,

--- a/src/services/ai-nutrition.js
+++ b/src/services/ai-nutrition.js
@@ -73,7 +73,7 @@ async function getRecentLogs(db, userId, days = 7) {
  * Build rule-based insights that are always available, then optionally
  * enhance with an AI-generated narrative summary.
  */
-export async function analyzeNutrition({ ai, db, user, date }) {
+export async function analyzeNutrition({ ai, db, user, date, env }) {
   const today = date || new Date().toISOString().split('T')[0];
   const [todayLog, recentLogs, targets] = await Promise.all([
     getDailyLog(db, user.id, today),
@@ -211,7 +211,9 @@ export async function analyzeNutrition({ ai, db, user, date }) {
       systemPrompt:
         'You are a direct, evidence-based fitness nutrition coach. Reply in 2-3 sentences max. Focus on the most actionable thing the user can do right now. Never exceed 60 words.',
       userPrompt: `Nutrition data:\n${promptSummary}\n\nGive one specific, actionable coaching tip for the rest of today.`,
-      maxTokens: 200
+      maxTokens: 200,
+      env,
+      gateway: { cacheTtl: 600, metadata: { feature: 'nutrition_analyze', userId: String(user.id) } }
     });
 
     if (result.success && result.text) {
@@ -238,7 +240,7 @@ export async function analyzeNutrition({ ai, db, user, date }) {
  * Suggest a meal that helps hit the user's remaining macros for the day.
  * Uses AI for variety; falls back to rule-based suggestions.
  */
-export async function suggestNextMeal({ ai, db, user, mealType = 'next' }) {
+export async function suggestNextMeal({ ai, db, user, mealType = 'next', env }) {
   const today = new Date().toISOString().split('T')[0];
   const [todayLog, targets] = await Promise.all([
     getDailyLog(db, user.id, today),
@@ -272,7 +274,9 @@ export async function suggestNextMeal({ ai, db, user, mealType = 'next' }) {
 Meal type hint: ${mealType}. Prefer whole foods. Portion sizes must be realistic.`,
     maxTokens: 800,
     parseJson: true,
-    fallbackJson: { suggestions: [fallback] }
+    fallbackJson: { suggestions: [fallback] },
+    env,
+    gateway: { cacheTtl: 300, metadata: { feature: 'meal_suggest', userId: String(user.id) } }
   });
 
   const parsed = result.parsed || { suggestions: [fallback] };
@@ -349,7 +353,7 @@ function buildFallbackSuggestion(remaining, mealType) {
  *
  * Example input:  "2 eggs, a slice of whole-wheat toast, and a banana"
  */
-export async function parseMealFromText({ ai, text }) {
+export async function parseMealFromText({ ai, text, env, userId }) {
   if (!text || text.trim().length < 2) {
     return { foods: [], error: 'Please describe what you ate.' };
   }
@@ -403,7 +407,14 @@ Output: {"foods":[{"name":"Chicken breast, grilled","quantity":6,"unit":"oz","ca
       model,
       maxTokens: 1200,
       parseJson: true,
-      fallbackJson: { foods: [] }
+      fallbackJson: { foods: [] },
+      env,
+      gateway: {
+        // Cache identical meal descriptions for 24h — common strings like
+        // "2 eggs and toast" benefit a lot from caching.
+        cacheTtl: 86400,
+        metadata: { feature: 'meal_parse', userId: String(userId || 'unknown') }
+      }
     });
     if (result.success && Array.isArray(result.parsed?.foods) && result.parsed.foods.length > 0) {
       break;

--- a/src/services/ai-realtime.js
+++ b/src/services/ai-realtime.js
@@ -328,3 +328,262 @@ export async function buildPreWorkoutContext(db, userId, programDayId) {
     last_workout: recentWorkouts[0] || null
   };
 }
+
+// ============================================================================
+// Context-aware set analysis
+//
+// The old `analyzePostSet()` only looked at the current set vs targets — it
+// produced generic messages with zero personalization. This version pulls:
+//   - The exercise's historical performance (last 6 sessions)
+//   - The user's current PR and trajectory
+//   - Recent training load (weekly volume, fatigue)
+//   - Program day context (muscle focus, remaining exercises)
+// …then passes the context to the AI for a personalized coaching tip.
+//
+// Rule-based output is always returned as the primary signal. AI enhances
+// with a narrative that references the user's actual history. Never blocks
+// on the AI — if the LLM times out or fails, the rule-based tip still ships.
+// ============================================================================
+
+async function fetchExerciseHistoryForAnalysis(db, userId, exerciseId, currentWorkoutId) {
+  // Last 6 sessions of this exercise (excluding the current workout)
+  const historyResult = await db.prepare(
+    `SELECT w.id AS workout_id, w.start_time, w.perceived_exertion,
+            s.set_number, s.weight_kg, s.reps, s.one_rep_max_kg
+     FROM sets s
+     JOIN workout_exercises we ON s.workout_exercise_id = we.id
+     JOIN workouts w ON we.workout_id = w.id
+     WHERE we.exercise_id = ? AND w.user_id = ? AND w.completed = 1
+       AND w.id != ?
+     ORDER BY w.start_time DESC, s.set_number ASC
+     LIMIT 30`
+  ).bind(exerciseId, userId, currentWorkoutId || 0).all();
+
+  const rows = historyResult.results || [];
+
+  // Group by workout
+  const byWorkout = new Map();
+  for (const row of rows) {
+    const key = row.workout_id;
+    if (!byWorkout.has(key)) {
+      byWorkout.set(key, {
+        workout_id: key,
+        date: row.start_time,
+        perceived_exertion: row.perceived_exertion,
+        sets: []
+      });
+    }
+    byWorkout.get(key).sets.push({
+      set_number: row.set_number,
+      weight_kg: row.weight_kg,
+      reps: row.reps,
+      one_rep_max_kg: row.one_rep_max_kg
+    });
+  }
+
+  return Array.from(byWorkout.values()).slice(0, 6);
+}
+
+async function fetchPersonalRecords(db, userId, exerciseId) {
+  try {
+    const pr = await db.prepare(
+      `SELECT MAX(weight_kg) AS max_weight,
+              MAX(one_rep_max_kg) AS max_1rm,
+              MAX(reps) AS max_reps
+       FROM sets s
+       JOIN workout_exercises we ON s.workout_exercise_id = we.id
+       JOIN workouts w ON we.workout_id = w.id
+       WHERE we.exercise_id = ? AND w.user_id = ? AND w.completed = 1`
+    ).bind(exerciseId, userId).first();
+    return {
+      max_weight_kg: pr?.max_weight || 0,
+      max_1rm_kg: pr?.max_1rm || 0,
+      max_reps: pr?.max_reps || 0
+    };
+  } catch {
+    return { max_weight_kg: 0, max_1rm_kg: 0, max_reps: 0 };
+  }
+}
+
+async function fetchRecentTrainingLoad(db, userId) {
+  try {
+    const result = await db.prepare(
+      `SELECT COUNT(*) AS session_count,
+              AVG(perceived_exertion) AS avg_rpe,
+              SUM(total_weight_kg) AS total_volume,
+              MAX(start_time) AS last_session
+       FROM workouts
+       WHERE user_id = ? AND completed = 1
+         AND start_time >= datetime('now', '-7 days')`
+    ).bind(userId).first();
+    return {
+      session_count: result?.session_count || 0,
+      avg_rpe: result?.avg_rpe || null,
+      total_volume_kg: result?.total_volume || 0,
+      last_session: result?.last_session || null
+    };
+  } catch {
+    return { session_count: 0, avg_rpe: null, total_volume_kg: 0, last_session: null };
+  }
+}
+
+function summarizeHistory(history) {
+  if (history.length === 0) return 'No previous sessions on record.';
+  const lines = history.slice(0, 4).map((w) => {
+    const sets = w.sets.map((s) => `${s.weight_kg}kg×${s.reps}`).join(', ');
+    const rpe = w.perceived_exertion ? ` RPE ${w.perceived_exertion}` : '';
+    return `${w.date?.split('T')[0] || w.date}: ${sets}${rpe}`;
+  });
+  return lines.join('\n');
+}
+
+function summarizeCurrentSets(sets) {
+  if (sets.length === 0) return 'none yet';
+  return sets.map((s, i) => `Set ${i + 1}: ${s.weight_kg}kg × ${s.reps}`).join(', ');
+}
+
+/**
+ * Full-context post-set analyzer — runs rule-based checks first, then asks
+ * the AI for a personalized coaching tip that references the user's actual
+ * training history.
+ */
+export async function analyzeSetWithContext({
+  ai, env, db, user,
+  exerciseId, workoutId,
+  currentSets = [],
+  targetReps = 10,
+  targetSets = 3
+}) {
+  // Rule-based insight first (always fast + always returned)
+  const ruleInsight = analyzePostSet({ currentSets, targetReps, targetSets });
+
+  if (!exerciseId || !db || !user) {
+    return ruleInsight ? { ...ruleInsight, source: 'rules' } : null;
+  }
+
+  // Fetch context in parallel — never block rule-based output on this
+  const [exercise, history, prs, load] = await Promise.all([
+    db.prepare('SELECT id, name, muscle_group, equipment, is_unilateral FROM exercises WHERE id = ?')
+      .bind(exerciseId).first().catch(() => null),
+    fetchExerciseHistoryForAnalysis(db, user.id, exerciseId, workoutId),
+    fetchPersonalRecords(db, user.id, exerciseId),
+    fetchRecentTrainingLoad(db, user.id)
+  ]);
+
+  const latestSet = currentSets[currentSets.length - 1];
+  const isAttemptingPR =
+    latestSet && latestSet.weight_kg > 0 && latestSet.weight_kg >= prs.max_weight_kg && prs.max_weight_kg > 0;
+
+  // Compute trend across recent sessions (did the user progress or stall?)
+  let trend = 'insufficient data';
+  let trendDetail = '';
+  if (history.length >= 2) {
+    const getMaxWeight = (w) => Math.max(0, ...w.sets.map((s) => s.weight_kg || 0));
+    const currentMax = Math.max(0, ...currentSets.map((s) => s.weight_kg || 0));
+    const lastMax = getMaxWeight(history[0]);
+    const twoAgoMax = getMaxWeight(history[1]);
+
+    if (currentMax > lastMax) {
+      trend = 'progressing';
+      trendDetail = `${lastMax}kg last session → ${currentMax}kg today`;
+    } else if (currentMax < lastMax && currentMax > 0) {
+      trend = 'regressing';
+      trendDetail = `${lastMax}kg last session → ${currentMax}kg today`;
+    } else if (currentMax === lastMax && currentMax === twoAgoMax) {
+      trend = 'stalled';
+      trendDetail = `${currentMax}kg for ${Math.min(3, history.length + 1)} consecutive sessions`;
+    } else {
+      trend = 'consistent';
+      trendDetail = `holding ${currentMax}kg`;
+    }
+  }
+
+  // Build a rich context object the client can display even without AI
+  const context = {
+    exercise: exercise ? {
+      id: exercise.id,
+      name: exercise.name,
+      muscle_group: exercise.muscle_group,
+      is_unilateral: !!exercise.is_unilateral
+    } : null,
+    personal_records: prs,
+    recent_history: history.slice(0, 3).map((w) => ({
+      date: w.date,
+      sets: w.sets,
+      perceived_exertion: w.perceived_exertion
+    })),
+    trend: { state: trend, detail: trendDetail },
+    recent_load: load,
+    current_sets: currentSets,
+    is_attempting_pr: isAttemptingPR
+  };
+
+  // If there's no AI binding, return rule-based + context (client will show
+  // rule message + a small history panel)
+  if (!ai) {
+    return {
+      ...(ruleInsight || {}),
+      type: ruleInsight?.type || 'context_only',
+      message: ruleInsight?.message || null,
+      action: ruleInsight?.action || null,
+      context,
+      source: 'rules'
+    };
+  }
+
+  // Compose a focused prompt — the 8B model is fast but tends to ramble;
+  // constraining to ~1-2 sentences keeps it coach-like.
+  const systemPrompt =
+    'You are an evidence-based strength coach giving real-time mid-workout feedback. ' +
+    'Respond in 1-2 short sentences (under 35 words) that reference the user\'s specific history or trend. ' +
+    'Be direct and specific — mention actual numbers when relevant. ' +
+    'If they are PR-attempting, encourage them. If stalled, suggest a concrete change (rest, rep scheme, deload). ' +
+    'If form breakdown is likely, flag it. No generic advice. No emojis. Plain text only.';
+
+  const userPrompt = [
+    `Exercise: ${exercise?.name || 'Unknown'} (${exercise?.muscle_group || 'unknown muscle group'})`,
+    `Today's sets so far: ${summarizeCurrentSets(currentSets)}`,
+    `Target: ${targetSets} sets × ${targetReps} reps`,
+    `Recent history (latest first):`,
+    summarizeHistory(history),
+    `Best lifts: ${prs.max_weight_kg}kg max weight, est. ${prs.max_1rm_kg?.toFixed?.(1) || prs.max_1rm_kg}kg 1RM`,
+    `Trend: ${trend}${trendDetail ? ` (${trendDetail})` : ''}`,
+    `Past 7 days: ${load.session_count} sessions${load.avg_rpe ? `, avg RPE ${load.avg_rpe.toFixed(1)}` : ''}`,
+    isAttemptingPR ? 'User is attempting a NEW PR this set.' : '',
+    ruleInsight ? `Rule-based flag: ${ruleInsight.type} — ${ruleInsight.message}` : 'No rule-based flag.',
+    '',
+    'Give one coaching sentence tailored to this specific lifter and this specific moment.'
+  ].filter(Boolean).join('\n');
+
+  const aiResult = await callAI(ai, {
+    systemPrompt,
+    userPrompt,
+    model: '@cf/meta/llama-3.1-8b-instruct',
+    maxTokens: 120,
+    env,
+    gateway: {
+      // Don't cache — every mid-workout moment is different
+      skipCache: true,
+      metadata: { feature: 'realtime_set_analysis', userId: String(user.id), exerciseId: String(exerciseId) }
+    }
+  });
+
+  let narrative = null;
+  if (aiResult.success && aiResult.text) {
+    narrative = aiResult.text.trim()
+      // Strip any quote wrapping the model might add
+      .replace(/^["']+|["']+$/g, '')
+      // Cap length as a safety net
+      .slice(0, 280);
+  }
+
+  // Prefer the AI narrative as the visible message, but keep the rule-based
+  // type/action so the overlay still renders its coloured border + action button
+  return {
+    type: ruleInsight?.type || (isAttemptingPR ? 'pr_attempt' : 'context'),
+    message: narrative || ruleInsight?.message || 'Keep going — focus on form.',
+    action: ruleInsight?.action || null,
+    context,
+    source: narrative ? 'ai' : 'rules'
+  };
+}

--- a/src/utils/ai-parser.js
+++ b/src/utils/ai-parser.js
@@ -70,13 +70,48 @@ export function parseAIJsonArray(text, fallback = []) {
 }
 
 /**
+ * Build the Cloudflare AI gateway options from an env binding.
+ *
+ * If `env.AI_GATEWAY_ID` is set (via wrangler.toml [vars] or a secret),
+ * every AI call is routed through that gateway. Benefits:
+ *   - Per-model + per-user analytics in the Cloudflare dashboard
+ *   - Request/response caching (set via `cacheTtl` per call)
+ *   - Rate limiting + cost controls
+ *   - Prompt logging for debugging
+ *
+ * If the env var is unset we fall through to direct binding calls.
+ *
+ * @param {object} env - Cloudflare Worker env bindings
+ * @param {object} [overrides] - per-call overrides (cacheTtl, skipCache, metadata)
+ * @returns {object | null}
+ */
+export function buildGatewayOptions(env, overrides = {}) {
+  const id = env?.AI_GATEWAY_ID;
+  if (!id) return null;
+
+  return {
+    id,
+    skipCache: overrides.skipCache ?? false,
+    cacheTtl: overrides.cacheTtl ?? 0,
+    ...(overrides.metadata ? { metadata: overrides.metadata } : {})
+  };
+}
+
+/**
  * Call a Cloudflare Workers AI model with consistent prompt handling.
+ * Automatically routes through the configured AI Gateway when
+ * `env.AI_GATEWAY_ID` is present.
+ *
  * @param {*} ai - c.env.AI binding
  * @param {object} opts
  * @param {string} opts.systemPrompt
  * @param {string} opts.userPrompt
  * @param {string} [opts.model='@cf/meta/llama-3.1-8b-instruct']
  * @param {number} [opts.maxTokens=1500]
+ * @param {boolean} [opts.parseJson=false]
+ * @param {*} [opts.fallbackJson=null]
+ * @param {object} [opts.env] - Worker env, required for gateway routing
+ * @param {object} [opts.gateway] - per-call gateway overrides (cacheTtl, skipCache, metadata)
  * @returns {Promise<{ success: boolean, text: string, parsed?: object, error?: string }>}
  */
 export async function callAI(ai, {
@@ -85,16 +120,24 @@ export async function callAI(ai, {
   model = '@cf/meta/llama-3.1-8b-instruct',
   maxTokens = 1500,
   parseJson = false,
-  fallbackJson = null
+  fallbackJson = null,
+  env = null,
+  gateway = null
 }) {
   try {
+    const runOptions = {};
+    const gatewayOptions = env ? buildGatewayOptions(env, gateway || {}) : null;
+    if (gatewayOptions) {
+      runOptions.gateway = gatewayOptions;
+    }
+
     const response = await ai.run(model, {
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt }
       ],
       max_tokens: maxTokens
-    });
+    }, Object.keys(runOptions).length > 0 ? runOptions : undefined);
 
     const text = response.response || '';
 

--- a/tests/unit/ai-realtime-context.test.js
+++ b/tests/unit/ai-realtime-context.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest';
+import { analyzeSetWithContext } from '../../src/services/ai-realtime.js';
+
+/**
+ * Minimal D1-style mock that routes SQL patterns to canned results.
+ */
+function mockDb({ exercise, history = [], prs, load }) {
+  return {
+    prepare(sql) {
+      return {
+        bind() {
+          return {
+            first: async () => {
+              if (sql.includes('FROM exercises')) return exercise;
+              if (sql.includes('MAX(weight_kg) AS max_weight')) return prs;
+              if (sql.includes('FROM workouts') && sql.includes("'-7 days'")) return load;
+              return null;
+            },
+            all: async () => {
+              if (sql.includes('FROM sets s') && sql.includes('JOIN workouts w')) {
+                // Flatten history into rows
+                const rows = [];
+                for (const wk of history) {
+                  for (const s of wk.sets) {
+                    rows.push({
+                      workout_id: wk.workout_id,
+                      start_time: wk.date,
+                      perceived_exertion: wk.perceived_exertion,
+                      set_number: s.set_number,
+                      weight_kg: s.weight_kg,
+                      reps: s.reps,
+                      one_rep_max_kg: s.one_rep_max_kg || 0
+                    });
+                  }
+                }
+                return { results: rows };
+              }
+              return { results: [] };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
+describe('analyzeSetWithContext', () => {
+  it('returns rule-based insight when DB lookup fails gracefully', async () => {
+    const result = await analyzeSetWithContext({
+      ai: null,
+      db: null,
+      user: null,
+      exerciseId: 1,
+      workoutId: 1,
+      currentSets: [{ weight_kg: 80, reps: 12 }],
+      targetReps: 10,
+      targetSets: 3
+    });
+
+    // Should fall back to pure rule-based
+    expect(result).toBeTruthy();
+    expect(result.source).toBe('rules');
+  });
+
+  it('pulls history and computes a progression trend', async () => {
+    const db = mockDb({
+      exercise: { id: 1, name: 'Bench Press', muscle_group: 'Chest', is_unilateral: 0 },
+      history: [
+        { workout_id: 10, date: '2026-04-15T10:00:00Z', perceived_exertion: 7, sets: [{ set_number: 1, weight_kg: 80, reps: 10 }, { set_number: 2, weight_kg: 80, reps: 9 }] },
+        { workout_id: 9,  date: '2026-04-12T10:00:00Z', perceived_exertion: 7, sets: [{ set_number: 1, weight_kg: 77.5, reps: 10 }] }
+      ],
+      prs: { max_weight: 80, max_1rm: 106, max_reps: 10 },
+      load: { session_count: 4, avg_rpe: 7.2, total_volume: 8500, last_session: '2026-04-15T10:00:00Z' }
+    });
+
+    const result = await analyzeSetWithContext({
+      ai: null, // No AI => rule + context only
+      db,
+      user: { id: 1 },
+      exerciseId: 1,
+      workoutId: 11,
+      currentSets: [{ weight_kg: 82.5, reps: 8 }],
+      targetReps: 10,
+      targetSets: 3
+    });
+
+    expect(result.context.exercise.name).toBe('Bench Press');
+    expect(result.context.recent_history).toHaveLength(2);
+    expect(result.context.personal_records.max_weight_kg).toBe(80);
+    expect(result.context.trend.state).toBe('progressing');
+    expect(result.context.is_attempting_pr).toBe(true); // 82.5 > 80
+  });
+
+  it('flags a stalled trend when max weight has not moved', async () => {
+    const db = mockDb({
+      exercise: { id: 2, name: 'Squat', muscle_group: 'Quads', is_unilateral: 0 },
+      history: [
+        { workout_id: 20, date: '2026-04-15T10:00:00Z', sets: [{ set_number: 1, weight_kg: 100, reps: 5 }] },
+        { workout_id: 19, date: '2026-04-12T10:00:00Z', sets: [{ set_number: 1, weight_kg: 100, reps: 5 }] }
+      ],
+      prs: { max_weight: 100, max_1rm: 116, max_reps: 5 },
+      load: { session_count: 3, avg_rpe: 8, total_volume: 3000, last_session: '2026-04-15T10:00:00Z' }
+    });
+
+    const result = await analyzeSetWithContext({
+      ai: null,
+      db,
+      user: { id: 1 },
+      exerciseId: 2,
+      workoutId: 21,
+      currentSets: [{ weight_kg: 100, reps: 5 }],
+      targetReps: 5,
+      targetSets: 3
+    });
+
+    expect(result.context.trend.state).toBe('stalled');
+    expect(result.context.trend.detail).toContain('100');
+  });
+
+  it('calls the AI and uses its response as the visible message', async () => {
+    const mockAi = {
+      run: vi.fn().mockResolvedValue({
+        response: '"Strong third set at 80kg. Rep count held steady — try 82.5kg next week for progression."'
+      })
+    };
+
+    const db = mockDb({
+      exercise: { id: 3, name: 'OHP', muscle_group: 'Shoulders', is_unilateral: 0 },
+      history: [
+        { workout_id: 30, date: '2026-04-12T10:00:00Z', sets: [{ set_number: 1, weight_kg: 80, reps: 10 }] }
+      ],
+      prs: { max_weight: 80, max_1rm: 106, max_reps: 10 },
+      load: { session_count: 2, avg_rpe: 7 }
+    });
+
+    const result = await analyzeSetWithContext({
+      ai: mockAi,
+      db,
+      user: { id: 1 },
+      exerciseId: 3,
+      workoutId: 31,
+      currentSets: [{ weight_kg: 80, reps: 10 }],
+      targetReps: 10,
+      targetSets: 3
+    });
+
+    expect(mockAi.run).toHaveBeenCalled();
+    expect(result.source).toBe('ai');
+    // Quote-stripping: leading/trailing quotes should be removed
+    expect(result.message.startsWith('"')).toBe(false);
+    expect(result.message).toContain('80kg');
+    expect(result.context).toBeTruthy();
+  });
+
+  it('falls back to rule-based message when AI returns empty', async () => {
+    const mockAi = {
+      run: vi.fn().mockResolvedValue({ response: '' })
+    };
+
+    const db = mockDb({
+      exercise: { id: 4, name: 'Deadlift', muscle_group: 'Back', is_unilateral: 0 },
+      history: [],
+      prs: { max_weight: 150, max_1rm: 175, max_reps: 5 },
+      load: { session_count: 1, avg_rpe: 7 }
+    });
+
+    const result = await analyzeSetWithContext({
+      ai: mockAi,
+      db,
+      user: { id: 1 },
+      exerciseId: 4,
+      workoutId: 41,
+      // Large rep dropoff should trigger a form_warning rule
+      currentSets: [
+        { weight_kg: 140, reps: 10 },
+        { weight_kg: 140, reps: 8 },
+        { weight_kg: 140, reps: 3 }
+      ],
+      targetReps: 10,
+      targetSets: 3
+    });
+
+    expect(result.type).toBe('form_warning');
+    expect(result.source).toBe('rules');
+    expect(result.message).toBeTruthy();
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,6 +28,15 @@ binding = "AI"
 # Environment variables
 [vars]
 ENVIRONMENT = "production"
+# AI Gateway — when set, every Workers AI call is routed through the
+# named gateway for analytics, caching, rate limiting, and cost controls.
+# See the Cloudflare dashboard: AI → AI Gateway → Create Gateway.
+# Replace the value below with your gateway slug (lowercase, no spaces).
+# To disable routing, comment this line out.
+AI_GATEWAY_ID = "fitness-coach"
 
-# JWT Secret (use wrangler secret put JWT_SECRET)
-# wrangler secret put JWT_SECRET
+# Secrets (set via CLI, never commit):
+#   wrangler secret put JWT_SECRET
+#   wrangler secret put USDA_API_KEY
+# Gateway ID is NOT secret (it appears in logs / browser responses only
+# as request metadata), so it lives in [vars] for easy rotation.


### PR DESCRIPTION
Three features in one PR.

## 1. Tailored in-workout AI insights

**Before**: the live coach only looked at sets logged in the current workout. Generic messages like 'On target' / 'Great opener' — no personalization.

**After**: new `analyzeSetWithContext()` pulls (in parallel, per logged set):
- Last 6 sessions of this exercise for this user
- Personal records (max weight, max 1RM, max reps)
- Past-7-days training load (session count, avg RPE, total volume)
- Current-session trend (progressing / stalled / regressing / consistent) with specific numeric detail

…then prompts the 8B model to reply in 1-2 sentences (<35 words) referencing the actual numbers. Rule-based output still returned as a primary signal for fail-safety.

**Frontend**:
- `POST /api/ai/realtime/analyze` now accepts `exercise_id` + `workout_id`
- Live-coach overlay shows a 'thinking' state during the round-trip
- New context-chips row shows trend, PR, and PR-attempt badge
- Source label ('AI · tailored' vs 'rules') so users see which path ran

**+5 unit tests** (DB mocking, trend detection, PR flagging, AI response use, fallback).

## 2. Cloudflare AI Gateway routing

New `buildGatewayOptions(env)` helper. When `env.AI_GATEWAY_ID` is set, every `ai.run()` call is routed through the named gateway for:
- Per-user + per-feature analytics
- Response caching (configurable TTL per call)
- Rate limiting + cost controls
- Prompt/response logging

**Gateway metadata** includes feature name + user id so the dashboard can slice usage. TTLs chosen per feature:
- `meal_parse` → 24h (repeat strings like "2 eggs" benefit hugely)
- `coach_analysis` / `exercise_coaching` → 5-30m
- `nutrition_analyze` → 10m
- `meal_suggest` → 5m
- `realtime_set_analysis` → skipCache (every moment is different)
- `coach_chat` → skipCache (conversational)

### Setup needed (after merge)
1. Cloudflare dashboard → **AI** → **AI Gateway** → **Create Gateway**
2. Name it `fitness-coach` (matches `wrangler.toml` `AI_GATEWAY_ID`)
3. Next deploy picks it up automatically — no code changes needed
4. To change the name, edit `AI_GATEWAY_ID` in `wrangler.toml` and redeploy
5. To disable, comment out the line in `wrangler.toml` → calls go direct

Zero-config fallback: if `AI_GATEWAY_ID` is unset, every call goes direct (same as before). No downtime during setup.

## 3. Cross-browser barcode scanner

**Before**: native `BarcodeDetector` API is Chrome/Edge/Android only. iOS Safari and Firefox users saw 'Auto-scan unavailable' and had to type the barcode.

**After**: new `barcode-decoder.js` with a two-tier strategy:
1. **Native `BarcodeDetector`** when available — no deps, fastest path, used by ~90% of users
2. **[@zxing/browser](https://github.com/zxing-js/browser) v0.1.5** loaded dynamically from jsDelivr ESM CDN when native API is missing — covers Safari/Firefox/iOS/WebView

ZXing is only loaded when the user **opens the scanner AND** doesn't have the native API, so Chrome users pay zero bundle cost. ZXing pkg is ~100 KiB gzipped.

**UI improvements**:
- Engine label in bottom-right: 'Native scanner' / 'ZXing fallback'
- Better error mapping (NotAllowedError → 'Camera access denied', etc.)
- Always show the camera preview when a camera is available

## Size impact
| Bundle | Before | After | Delta |
|---|---:|---:|---:|
| Worker | 360 KiB | 378 KiB | +18 KiB |
| Frontend JS | 410 KiB | 418 KiB | +8 KiB |
| ZXing (lazy) | 0 | ~100 KiB gz | only when needed |

**104 tests passing.**