### PR TITLE
Nutrition hotfixes: View all entries + Log saved meal

### DIFF
--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -3000,6 +3000,37 @@
   font-size: var(--text-lg);
 }
 
+/* ---------- Nutrition entries modal ---------- */
+.nutrition-entries-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-1) var(--space-2);
+  margin-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.nutrition-entry-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface-sunken);
+  border-radius: var(--radius-md);
+}
+
+.nutrition-entry-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
 /* ---------- Barcode scanner ---------- */
 .barcode-scanner-layout {
   display: flex;

--- a/frontend/src/features/nutrition/saved-meals.js
+++ b/frontend/src/features/nutrition/saved-meals.js
@@ -468,49 +468,174 @@ export async function logAllQuick() {
 
 // ============================================================================
 // Nutrition entries list (edit/delete individual entries)
+//
+// Shows the last 14 days of protein / water / creatine entries grouped
+// by date (newest first). Each row can be deleted inline. The backend
+// has a single `/nutrition/entries` endpoint that takes optional
+// start_date + end_date query params — no `/entries/today` route exists
+// (that was the bug: frontend was calling a 404 URL).
 // ============================================================================
 
-export async function loadNutritionEntries() {
-  try {
-    const data = await api.get('/nutrition/entries/today');
-    const entries = data.entries || [];
+const ENTRY_TYPE_META = {
+  protein: { icon: 'fa-drumstick-bite', color: 'var(--color-secondary)', label: 'Protein' },
+  water:   { icon: 'fa-tint',           color: 'var(--color-primary)',   label: 'Water' },
+  creatine:{ icon: 'fa-flask',          color: '#8b5cf6',                label: 'Creatine' }
+};
 
-    openModal({
-      title: "Today's Entries",
-      size: 'default',
-      content: String(html`
-        <div class="stack stack-sm" style="max-height: 500px; overflow-y: auto;">
-          ${entries.length === 0
-            ? html`<div class="empty-state"><div class="empty-state-description">No entries today.</div></div>`
-            : entries.map((e) => html`
-                <div class="saved-meal-row">
-                  <div>
-                    <strong>${e.entry_type}</strong>
-                    <div class="text-muted" style="font-size: var(--text-xs);">
-                      ${Math.round(e.amount)}${e.unit} · ${new Date(e.logged_at).toLocaleTimeString()}
-                    </div>
-                  </div>
-                  <button class="btn btn-ghost btn-icon btn-sm text-danger" data-delete-entry="${e.id}">
-                    <i class="fas fa-trash"></i>
-                  </button>
-                </div>
-              `)}
-        </div>
-      `),
-      actions: [{ label: 'Close', variant: 'btn-outline' }],
-      onOpen: ({ element }) => {
-        element.addEventListener('click', async (event) => {
-          const btn = event.target.closest('[data-delete-entry]');
-          if (!btn) return;
-          await deleteNutritionEntry(parseInt(btn.getAttribute('data-delete-entry'), 10));
-          closeTopModal();
-          loadNutritionEntries();
-        });
-      }
-    });
-  } catch (err) {
-    toast.error(`Error: ${err.message}`);
+function formatEntryTime(iso) {
+  if (!iso) return '';
+  const d = new Date(iso.includes('T') || iso.includes('Z') ? iso : iso.replace(' ', 'T') + 'Z');
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+function formatEntryDateHeader(dateKey, today) {
+  if (dateKey === today) return 'Today';
+  const y = new Date(today);
+  y.setDate(y.getDate() - 1);
+  const yesterday = y.toISOString().split('T')[0];
+  if (dateKey === yesterday) return 'Yesterday';
+  // Parse YYYY-MM-DD as local date for display
+  const [yr, mo, dy] = dateKey.split('-').map(Number);
+  const d = new Date(yr, mo - 1, dy);
+  return d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+function groupEntriesByDate(entries) {
+  const groups = new Map();
+  for (const e of entries) {
+    // logged_at is UTC from DB; take the local-date key for grouping
+    const raw = e.logged_at || '';
+    const iso = raw.includes('T') || raw.includes('Z') ? raw : raw.replace(' ', 'T') + 'Z';
+    const d = new Date(iso);
+    const key = Number.isNaN(d.getTime())
+      ? 'unknown'
+      : `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(e);
   }
+  return Array.from(groups.entries())
+    .map(([date, items]) => ({ date, items }))
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
+}
+
+function renderEntriesBody(entries) {
+  if (!entries || entries.length === 0) {
+    return html`
+      <div class="empty-state" style="padding: var(--space-8) var(--space-4);">
+        <div class="empty-state-icon">🍽️</div>
+        <div class="empty-state-title">No entries yet</div>
+        <div class="empty-state-description">
+          Log protein, water, or creatine and it'll appear here.
+        </div>
+      </div>
+    `;
+  }
+
+  const today = new Date().toISOString().split('T')[0];
+  const groups = groupEntriesByDate(entries);
+
+  return html`
+    <div class="stack stack-md" style="max-height: 500px; overflow-y: auto;">
+      ${groups.map((group) => {
+        const totals = group.items.reduce((acc, e) => {
+          acc[e.entry_type] = (acc[e.entry_type] || 0) + (Number(e.amount) || 0);
+          return acc;
+        }, {});
+        return html`
+          <div>
+            <div class="nutrition-entries-group-header">
+              <strong>${formatEntryDateHeader(group.date, today)}</strong>
+              <span class="text-muted" style="font-size: var(--text-xs);">
+                ${totals.protein ? `${Math.round(totals.protein)}g P` : ''}
+                ${totals.water ? ` · ${Math.round(totals.water)}ml W` : ''}
+                ${totals.creatine ? ` · ${Math.round(totals.creatine * 10) / 10}g C` : ''}
+              </span>
+            </div>
+            <div class="stack stack-sm">
+              ${group.items.map((e) => {
+                const meta = ENTRY_TYPE_META[e.entry_type] || {
+                  icon: 'fa-utensils', color: 'var(--color-text-muted)', label: e.entry_type
+                };
+                return html`
+                  <div class="nutrition-entry-row">
+                    <div class="nutrition-entry-icon" style="background: ${meta.color}20; color: ${meta.color};">
+                      <i class="fas ${meta.icon}"></i>
+                    </div>
+                    <div style="flex: 1; min-width: 0;">
+                      <strong>${meta.label}</strong>
+                      <div class="text-muted" style="font-size: var(--text-xs);">
+                        ${Math.round((Number(e.amount) || 0) * 10) / 10}${e.unit || ''}
+                        · ${formatEntryTime(e.logged_at)}
+                        ${e.notes ? ` · ${e.notes}` : ''}
+                      </div>
+                    </div>
+                    <button class="btn btn-ghost btn-icon btn-sm text-danger"
+                            data-delete-entry="${e.id}" title="Delete entry">
+                      <i class="fas fa-trash"></i>
+                    </button>
+                  </div>
+                `;
+              })}
+            </div>
+          </div>
+        `;
+      })}
+    </div>
+  `;
+}
+
+export async function loadNutritionEntries() {
+  // Last 14 days window (matches the "Last 14 Days" section the button sits in)
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - 13); // inclusive 14-day window
+  const start = startDate.toISOString().split('T')[0];
+  const end = endDate.toISOString().split('T')[0];
+
+  let data;
+  try {
+    data = await api.get(
+      `/nutrition/entries?start_date=${start}&end_date=${end}`
+    );
+  } catch (err) {
+    toast.error(`Couldn't load entries: ${err.message}`);
+    return;
+  }
+
+  const entries = Array.isArray(data?.entries) ? data.entries : [];
+
+  const api_ = openModal({
+    title: 'Nutrition Entries (Last 14 Days)',
+    size: 'default',
+    content: String(renderEntriesBody(entries)),
+    actions: [{ label: 'Close', variant: 'btn-outline' }],
+    onOpen: ({ element }) => {
+      element.addEventListener('click', async (event) => {
+        const btn = event.target.closest('[data-delete-entry]');
+        if (!btn) return;
+        const id = parseInt(btn.getAttribute('data-delete-entry'), 10);
+        if (!id) return;
+
+        await deleteNutritionEntry(id);
+        // Re-fetch + re-render the modal body in place (don't close + reopen
+        // — that flashes the modal and resets scroll position).
+        try {
+          const refreshed = await api.get(
+            `/nutrition/entries?start_date=${start}&end_date=${end}`
+          );
+          const body = element.querySelector('.modal-body');
+          if (body) {
+            body.innerHTML = String(renderEntriesBody(refreshed?.entries || []));
+          }
+        } catch (err) {
+          console.warn('Failed to refresh entries list:', err);
+          closeTopModal();
+        }
+      });
+    }
+  });
+  return api_;
 }
 
 export function editNutritionEntry(id, type, currentAmount) {

--- a/src/routes/nutrition.js
+++ b/src/routes/nutrition.js
@@ -1917,67 +1917,112 @@ nutrition.delete('/saved-meals/:id', async (c) => {
 nutrition.post('/saved-meals/:id/log', async (c) => {
   const user = requireAuth(c);
   const mealId = c.req.param('id');
-  const body = await c.req.json();
   const db = c.env.DB;
-  
+
+  // Body is optional — the frontend logs saved meals with no body, but
+  // advanced callers may pass { date, meal_type } to override.
+  let body = {};
+  try {
+    const ct = c.req.header('content-type') || '';
+    if (ct.includes('application/json')) {
+      const text = await c.req.text();
+      if (text && text.trim().length > 0) body = JSON.parse(text);
+    }
+  } catch (_) {
+    body = {};
+  }
+
   const { date, meal_type } = body;
   const logDate = date || new Date().toISOString().split('T')[0];
-  
+
   // Get the saved meal
   const savedMeal = await db.prepare(
     'SELECT * FROM saved_meals WHERE id = ? AND user_id = ?'
   ).bind(mealId, user.id).first();
-  
+
   if (!savedMeal) {
     return c.json({ error: 'Saved meal not found' }, 404);
   }
-  
-  // Create or get today's meal entry
+
+  const effectiveMealType = meal_type || savedMeal.meal_type || 'snack';
+
+  // Create or get today's meal entry so the saved meal also appears in the
+  // "Today's meals" list on the Nutrition screen.
   let meal = await db.prepare(
     'SELECT * FROM meals WHERE user_id = ? AND date = ? AND meal_type = ?'
-  ).bind(user.id, logDate, meal_type || savedMeal.meal_type || 'snack').first();
-  
+  ).bind(user.id, logDate, effectiveMealType).first();
+
   if (!meal) {
     meal = await db.prepare(
       `INSERT INTO meals (user_id, date, meal_type, name) VALUES (?, ?, ?, ?) RETURNING *`
-    ).bind(user.id, logDate, meal_type || savedMeal.meal_type || 'snack', savedMeal.name).first();
+    ).bind(user.id, logDate, effectiveMealType, savedMeal.name).first();
   }
-  
-  // Get saved meal foods and add them
+
+  // Copy saved-meal foods (if any) into meal_foods so the meal card shows
+  // its ingredients. Saved meals created from recipe URLs or pure macros
+  // will have no foods — that's fine, we still update the daily log below.
   const savedFoods = await db.prepare(
     'SELECT * FROM saved_meal_foods WHERE saved_meal_id = ?'
   ).bind(mealId).all();
-  
+
   for (const food of (savedFoods.results || [])) {
     await db.prepare(
       `INSERT INTO meal_foods (meal_id, food_id, quantity, unit, calories, protein_g, carbs_g, fat_g, notes)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).bind(meal.id, food.food_id, food.quantity, food.unit, food.calories, food.protein_g, food.carbs_g, food.fat_g, food.custom_name).run();
+    ).bind(
+      meal.id,
+      food.food_id,
+      food.quantity,
+      food.unit,
+      food.calories,
+      food.protein_g,
+      food.carbs_g,
+      food.fat_g,
+      food.custom_name
+    ).run();
   }
-  
-  // Update nutrition log
+
+  // Normalize macros from the saved meal (any field may be null).
+  const calories = Math.max(0, Math.round(Number(savedMeal.calories) || 0));
+  const protein = Math.round((Number(savedMeal.protein_g) || 0) * 10) / 10;
+  const carbs = Math.round((Number(savedMeal.carbs_g) || 0) * 10) / 10;
+  const fat = Math.round((Number(savedMeal.fat_g) || 0) * 10) / 10;
+  const fiber = Math.round((Number(savedMeal.fiber_g) || 0) * 10) / 10;
+
+  // Update daily nutrition log with the FULL macro breakdown so the rings
+  // and AI nutrition coach see the logged saved meal correctly. Prior to
+  // this fix only protein was added, leaving calories/carbs/fat silently
+  // missing from the daily totals.
   await db.prepare(
-    `INSERT INTO nutrition_log (user_id, date, protein_grams, updated_at)
-     VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+    `INSERT INTO nutrition_log
+       (user_id, date, calories, protein_grams, carbs_grams, fat_grams, fiber_grams, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
      ON CONFLICT(user_id, date) DO UPDATE SET
-       protein_grams = protein_grams + excluded.protein_grams,
+       calories = COALESCE(calories, 0) + excluded.calories,
+       protein_grams = COALESCE(protein_grams, 0) + excluded.protein_grams,
+       carbs_grams = COALESCE(carbs_grams, 0) + excluded.carbs_grams,
+       fat_grams = COALESCE(fat_grams, 0) + excluded.fat_grams,
+       fiber_grams = COALESCE(fiber_grams, 0) + excluded.fiber_grams,
        updated_at = CURRENT_TIMESTAMP`
-  ).bind(user.id, logDate, Math.round(savedMeal.protein_g)).run();
-  
+  ).bind(user.id, logDate, calories, protein, carbs, fat, fiber).run();
+
   // Update saved meal usage
   await db.prepare(
     `UPDATE saved_meals SET use_count = use_count + 1, last_used = CURRENT_TIMESTAMP WHERE id = ?`
   ).bind(mealId).run();
-  
-  return c.json({ 
+
+  return c.json({
     logged: {
       meal_name: savedMeal.name,
-      calories: savedMeal.calories,
-      protein_g: savedMeal.protein_g,
-      carbs_g: savedMeal.carbs_g,
-      fat_g: savedMeal.fat_g
+      meal_type: effectiveMealType,
+      date: logDate,
+      calories,
+      protein_g: protein,
+      carbs_g: carbs,
+      fat_g: fat,
+      fiber_g: fiber
     },
-    message: 'Meal logged' 
+    message: 'Meal logged'
   });
 });
 


### PR DESCRIPTION
## Summary

Two small nutrition bugs reported while testing, fixed together.

### 1. "View all entries" button returned an error

The Nutrition screen's **View all entries** action hit `/nutrition/entries/today`, a route that does not exist — the real endpoint is `/nutrition/entries?start_date=…&end_date=…`. Any tap on that button produced a 404 toast.

**Fix:** `loadNutritionEntries()` now calls `/nutrition/entries` with a 14-day window. The modal was also polished:

- Entries grouped by local date with **Today / Yesterday / Weekday** headers
- Per-day subtotals for protein (g) / water (ml) / creatine (g)
- Typed icons per entry (💪 protein, 💧 water, 💊 creatine)
- In-place refresh after delete — no full-screen reload
- Empty state when the 14-day window has no entries

### 2. "Log" on a saved meal returned an error, and even when it worked rings didn't move

Two compounding bugs in `POST /nutrition/saved-meals/:id/log`:

**A. Empty-body JSON parse error** — the user-visible failure.
The frontend posts with no body, but the handler did `await c.req.json()` unconditionally, which throws on empty bodies. Fix: parse the body defensively (read text, JSON.parse only if non-empty). `date` and `meal_type` overrides still supported for advanced callers.

**B. Only `protein_grams` was written to `nutrition_log`.**
Since migration 0027 the table also has `calories`, `carbs_grams`, `fat_grams`, `fiber_grams`. Logging a 600-kcal saved meal added ~0 to the calorie/carb/fat rings. Fix: write the full macro breakdown with the same `COALESCE(...) + 0` upsert pattern as the canonical `/meals/log` handler. Null-safe coercion prevents NaN binding when a saved meal has a missing macro.

The legacy `meals` + `meal_foods` rows are still written so the logged saved meal keeps appearing in "Today's meals", and recipe-URL saved meals (no food rows) pass through the existing empty-loop path.

## Verification

- `npm test` — 111/111 pass
- `npx wrangler deploy --dry-run` — clean build, bundle 379 KiB / 79 KiB gzipped
- No migration needed — `nutrition_log` columns from 0027 already live on remote

## Files

- `src/routes/nutrition.js` — rewrote `/saved-meals/:id/log` handler
- `frontend/src/features/nutrition/saved-meals.js` — rewrote `loadNutritionEntries()`
- `frontend/css/components.css` — added `.nutrition-entries-group-header`, `.nutrition-entry-row`, `.nutrition-entry-icon` styles