### PR TITLE
Fix AI Coach buttons, Stats calendar clicks, and Nutrition Entries meals

### DIFF
--- a/frontend/src/features/ai-coach/coaching-modals.js
+++ b/frontend/src/features/ai-coach/coaching-modals.js
@@ -30,72 +30,172 @@ function formatText(text) {
 /**
  * Full AI coaching analysis modal — displays comprehensive analysis from
  * the /api/ai/coach/generate endpoint.
+ *
+ * Backend response shapes we need to handle:
+ *   { success: true,  analysis: {...}, training_data, generated_at }
+ *   { success: true,  raw_response: "…", parsing_failed: true, training_data }
+ *   { success: false, message: "Need at least 3 completed workouts…", recommendations: [] }
+ *   { success: false, error: "…", training_data }
+ *
+ * The previous implementation read `analysis.data` which never exists,
+ * so every button press opened an empty modal.
  */
 export async function generateAICoaching() {
+  let response;
   try {
-    const analysis = await withLoading('Generating coaching analysis…', async () => {
+    response = await withLoading('Generating coaching analysis…', async () => {
       return await api.post('/ai/coach/generate');
     });
+  } catch (err) {
+    toast.error(`Coaching analysis failed: ${err.message}`);
+    return;
+  }
 
-    const data = analysis.data || {};
+  // Not enough data case — show a friendly explainer instead of an empty modal.
+  if (response && response.success === false) {
+    const message = response.message || response.error || 'Unable to generate a coaching analysis right now.';
+    openModal({
+      title: 'Your AI Coaching Analysis',
+      size: 'default',
+      content: String(html`
+        <div class="empty-state" style="padding: var(--space-6) var(--space-4);">
+          <div class="empty-state-icon">🤖</div>
+          <div class="empty-state-title">Not enough data yet</div>
+          <div class="empty-state-description">${message}</div>
+          <div class="text-muted" style="margin-top: var(--space-3); font-size: var(--text-sm);">
+            Log a few more complete workouts and try again.
+          </div>
+        </div>
+      `),
+      actions: [{ label: 'Close', primary: true, variant: 'btn-primary' }]
+    });
+    return;
+  }
 
+  // JSON parse failure fallback — show the raw model output so the user at
+  // least gets the insight (rare, but possible when the model drifts).
+  if (response && response.parsing_failed && response.raw_response) {
     openModal({
       title: 'Your AI Coaching Analysis',
       size: 'wide',
       content: String(html`
-        <div class="stack stack-lg">
-          ${data.overall_assessment
-            ? html`
-                <div class="ai-coaching-section ai-coaching-hero">
-                  <h3><i class="fas fa-brain"></i> Overall Assessment</h3>
-                  <div class="ai-coaching-content">${raw(formatText(data.overall_assessment))}</div>
-                </div>
-              `
-            : ''}
-
-          ${data.strengths?.length
-            ? html`
-                <div class="ai-coaching-section">
-                  <h3 class="text-success"><i class="fas fa-check-circle"></i> Your Strengths</h3>
-                  <ul>${data.strengths.map((s) => html`<li>${s}</li>`)}</ul>
-                </div>
-              `
-            : ''}
-
-          ${data.recommendations?.length
-            ? html`
-                <div class="ai-coaching-section">
-                  <h3 class="text-primary"><i class="fas fa-lightbulb"></i> Recommendations</h3>
-                  <div class="stack stack-sm">
-                    ${data.recommendations.map((r) => html`
-                      <div class="insight-card insight-${r.priority || 'medium'}">
-                        <strong>${r.title}</strong>
-                        <p class="text-muted" style="margin-top: var(--space-1); font-size: var(--text-sm);">${r.description}</p>
-                        ${r.action ? html`<p class="text-primary" style="margin-top: var(--space-2); font-size: var(--text-sm);"><i class="fas fa-arrow-right"></i> ${r.action}</p>` : ''}
-                      </div>
-                    `)}
-                  </div>
-                </div>
-              `
-            : ''}
-
-          ${data.action_steps?.length
-            ? html`
-                <div class="ai-coaching-section">
-                  <h3 class="text-warning"><i class="fas fa-tasks"></i> Action Steps</h3>
-                  <ol>${data.action_steps.map((s) => html`<li>${s}</li>`)}</ol>
-                </div>
-              `
-            : ''}
+        <div class="ai-coaching-section">
+          <h3><i class="fas fa-brain"></i> Analysis</h3>
+          <div class="ai-coaching-content">${raw(formatText(response.raw_response))}</div>
         </div>
       `),
-      actions: [
-        { label: 'Close', primary: true, variant: 'btn-primary' }
-      ]
+      actions: [{ label: 'Close', primary: true, variant: 'btn-primary' }]
     });
-  } catch (err) {
-    toast.error(`Coaching analysis failed: ${err.message}`);
+    return;
   }
+
+  // Happy path — backend returns { success: true, analysis: {...} }.
+  const data = (response && response.analysis) || {};
+  const hasAnyContent =
+    data.overall_assessment ||
+    data.strengths?.length ||
+    data.areas_for_improvement?.length ||
+    data.recommendations?.length ||
+    data.action_steps?.length ||
+    data.next_workout_tips?.length ||
+    data.weekly_focus;
+
+  openModal({
+    title: 'Your AI Coaching Analysis',
+    size: 'wide',
+    content: String(html`
+      <div class="stack stack-lg">
+        ${!hasAnyContent
+          ? html`
+              <div class="empty-state" style="padding: var(--space-6) var(--space-4);">
+                <div class="empty-state-icon">🤖</div>
+                <div class="empty-state-title">No analysis available</div>
+                <div class="empty-state-description">
+                  The coach wasn't able to produce an analysis from your recent training. Try again after your next workout.
+                </div>
+              </div>
+            `
+          : ''}
+
+        ${data.overall_assessment
+          ? html`
+              <div class="ai-coaching-section ai-coaching-hero">
+                <h3><i class="fas fa-brain"></i> Overall Assessment</h3>
+                <div class="ai-coaching-content">${raw(formatText(data.overall_assessment))}</div>
+              </div>
+            `
+          : ''}
+
+        ${data.strengths?.length
+          ? html`
+              <div class="ai-coaching-section">
+                <h3 class="text-success"><i class="fas fa-check-circle"></i> Your Strengths</h3>
+                <ul>${data.strengths.map((s) => html`<li>${s}</li>`)}</ul>
+              </div>
+            `
+          : ''}
+
+        ${data.areas_for_improvement?.length
+          ? html`
+              <div class="ai-coaching-section">
+                <h3 class="text-warning"><i class="fas fa-bullseye"></i> Areas to Improve</h3>
+                <ul>${data.areas_for_improvement.map((s) => html`<li>${s}</li>`)}</ul>
+              </div>
+            `
+          : ''}
+
+        ${data.recommendations?.length
+          ? html`
+              <div class="ai-coaching-section">
+                <h3 class="text-primary"><i class="fas fa-lightbulb"></i> Recommendations</h3>
+                <div class="stack stack-sm">
+                  ${data.recommendations.map((r) => html`
+                    <div class="insight-card insight-${r.priority || 'medium'}">
+                      <strong>${r.title || ''}</strong>
+                      ${r.description ? html`<p class="text-muted" style="margin-top: var(--space-1); font-size: var(--text-sm);">${r.description}</p>` : ''}
+                      ${r.action_steps?.length
+                        ? html`<ul style="margin-top: var(--space-2); font-size: var(--text-sm);">${r.action_steps.map((step) => html`<li>${step}</li>`)}</ul>`
+                        : ''}
+                      ${r.expected_outcome ? html`<p class="text-primary" style="margin-top: var(--space-2); font-size: var(--text-sm);"><i class="fas fa-arrow-right"></i> ${r.expected_outcome}</p>` : ''}
+                    </div>
+                  `)}
+                </div>
+              </div>
+            `
+          : ''}
+
+        ${data.next_workout_tips?.length
+          ? html`
+              <div class="ai-coaching-section">
+                <h3 class="text-primary"><i class="fas fa-dumbbell"></i> Next Workout Tips</h3>
+                <ul>${data.next_workout_tips.map((s) => html`<li>${s}</li>`)}</ul>
+              </div>
+            `
+          : ''}
+
+        ${data.weekly_focus
+          ? html`
+              <div class="ai-coaching-section ai-coaching-hero">
+                <h3><i class="fas fa-star"></i> This Week's Focus</h3>
+                <div class="ai-coaching-content">${raw(formatText(data.weekly_focus))}</div>
+              </div>
+            `
+          : ''}
+
+        ${data.action_steps?.length
+          ? html`
+              <div class="ai-coaching-section">
+                <h3 class="text-warning"><i class="fas fa-tasks"></i> Action Steps</h3>
+                <ol>${data.action_steps.map((s) => html`<li>${s}</li>`)}</ol>
+              </div>
+            `
+          : ''}
+      </div>
+    `),
+    actions: [
+      { label: 'Close', primary: true, variant: 'btn-primary' }
+    ]
+  });
 }
 
 /**

--- a/frontend/src/features/analytics/advanced-analytics.js
+++ b/frontend/src/features/analytics/advanced-analytics.js
@@ -232,48 +232,73 @@ function renderImbalances(balance) {
   `;
 }
 
+/**
+ * Advanced Analytics modal — opens the full ML-powered dashboard
+ * (recovery, consistency, muscle balance, strength predictions, volume
+ * forecast, imbalances, AI insights) in a wide modal.
+ *
+ * Previously this rendered into a DOM element `#advancedAnalyticsSection`
+ * that the migrated Insights screen never actually creates, so the button
+ * appeared to do nothing. Using a modal makes it work regardless of what
+ * tab the user is on and matches the "Full Analysis" button pattern.
+ */
 export async function loadAdvancedAnalytics() {
-  const container = document.getElementById('advancedAnalyticsSection');
-  if (!container) return;
-
-  container.innerHTML = String(html`
-    <div class="card"><div class="skeleton skeleton-card"></div></div>
-  `);
-
+  let data;
   try {
-    const data = await api.get('/analytics/advanced');
-
-    container.innerHTML = String(html`
-      <div class="stack stack-lg">
-        <div class="card advanced-hero">
-          <h2><i class="fas fa-brain"></i> Advanced Analytics</h2>
-          <p>ML-powered predictions and insights based on ${data.summary?.total_workouts_analyzed || 0} workouts.</p>
-        </div>
-
-        <div class="grid grid-cols-auto">
-          ${renderRecoveryCard(data.recovery)}
-          ${renderConsistencyCard(data.consistency)}
-          ${renderBalanceCard(data.muscle_balance)}
-          ${renderTrendCard(data.volume_predictions)}
-        </div>
-
-        ${renderInsights(data.ai_insights)}
-        ${renderStrengthPredictions(data.strength_predictions)}
-        ${renderVolumeForecast(data.volume_predictions)}
-        ${renderImbalances(data.muscle_balance)}
-      </div>
-    `);
+    data = await api.get('/analytics/advanced');
   } catch (err) {
     console.error('Error loading advanced analytics:', err);
-    container.innerHTML = String(html`
-      <div class="card">
-        <div class="empty-state">
-          <div class="empty-state-icon">⚠️</div>
-          <div class="empty-state-description">${err.message}</div>
-        </div>
-      </div>
-    `);
+    toast.error(`Couldn't load advanced analytics: ${err.message}`);
+    return;
   }
+
+  if (!data || typeof data !== 'object') {
+    toast.info('No advanced analytics data available yet.');
+    return;
+  }
+
+  const totalWorkouts = data.summary?.total_workouts_analyzed || 0;
+
+  openModal({
+    title: 'Advanced Analytics',
+    size: 'wide',
+    content: String(html`
+      <div class="stack stack-lg">
+        <div class="card advanced-hero">
+          <h2 style="margin: 0;"><i class="fas fa-brain"></i> ML-Powered Insights</h2>
+          <p class="text-muted" style="margin-top: var(--space-2);">
+            Predictions and analysis based on
+            ${totalWorkouts === 1 ? '1 workout' : `${totalWorkouts} workouts`}.
+          </p>
+        </div>
+
+        ${totalWorkouts === 0
+          ? html`
+              <div class="empty-state" style="padding: var(--space-6) var(--space-4);">
+                <div class="empty-state-icon">📊</div>
+                <div class="empty-state-title">Not enough data yet</div>
+                <div class="empty-state-description">
+                  Log a few workouts and advanced analytics will unlock.
+                </div>
+              </div>
+            `
+          : html`
+              <div class="grid grid-cols-auto">
+                ${renderRecoveryCard(data.recovery)}
+                ${renderConsistencyCard(data.consistency)}
+                ${renderBalanceCard(data.muscle_balance)}
+                ${renderTrendCard(data.volume_predictions)}
+              </div>
+
+              ${renderInsights(data.ai_insights)}
+              ${renderStrengthPredictions(data.strength_predictions)}
+              ${renderVolumeForecast(data.volume_predictions)}
+              ${renderImbalances(data.muscle_balance)}
+            `}
+      </div>
+    `),
+    actions: [{ label: 'Close', primary: true, variant: 'btn-primary' }]
+  });
 }
 
 // ============================================================================

--- a/frontend/src/features/nutrition/saved-meals.js
+++ b/frontend/src/features/nutrition/saved-meals.js
@@ -467,20 +467,32 @@ export async function logAllQuick() {
 }
 
 // ============================================================================
-// Nutrition entries list (edit/delete individual entries)
+// Nutrition activity feed (protein/water/creatine entries + logged meals)
 //
-// Shows the last 14 days of protein / water / creatine entries grouped
-// by date (newest first). Each row can be deleted inline. The backend
-// has a single `/nutrition/entries` endpoint that takes optional
-// start_date + end_date query params — no `/entries/today` route exists
-// (that was the bug: frontend was calling a 404 URL).
+// The "View all entries" modal previously only pulled from
+// /nutrition/entries (protein / water / creatine only) — so foods and
+// meals logged through the meal-logger, barcode scanner, AI parser, or
+// saved-meal templates were silently omitted. This now calls the unified
+// /nutrition/activity endpoint which returns a merged `items[]` with a
+// `kind` discriminator.
 // ============================================================================
 
 const ENTRY_TYPE_META = {
-  protein: { icon: 'fa-drumstick-bite', color: 'var(--color-secondary)', label: 'Protein' },
-  water:   { icon: 'fa-tint',           color: 'var(--color-primary)',   label: 'Water' },
-  creatine:{ icon: 'fa-flask',          color: '#8b5cf6',                label: 'Creatine' }
+  protein:  { icon: 'fa-drumstick-bite', color: 'var(--color-secondary)', label: 'Protein' },
+  water:    { icon: 'fa-tint',           color: 'var(--color-primary)',   label: 'Water' },
+  creatine: { icon: 'fa-flask',          color: '#8b5cf6',                label: 'Creatine' }
 };
+
+const MEAL_TYPE_META = {
+  breakfast: { icon: 'fa-sun',        color: '#f59e0b', label: 'Breakfast' },
+  lunch:     { icon: 'fa-utensils',   color: '#10b981', label: 'Lunch' },
+  dinner:    { icon: 'fa-moon',       color: '#6366f1', label: 'Dinner' },
+  snack:     { icon: 'fa-cookie-bite', color: '#8b5cf6', label: 'Snack' }
+};
+
+function mealMeta(mealType) {
+  return MEAL_TYPE_META[mealType] || MEAL_TYPE_META.snack;
+}
 
 function formatEntryTime(iso) {
   if (!iso) return '';
@@ -495,94 +507,149 @@ function formatEntryDateHeader(dateKey, today) {
   y.setDate(y.getDate() - 1);
   const yesterday = y.toISOString().split('T')[0];
   if (dateKey === yesterday) return 'Yesterday';
-  // Parse YYYY-MM-DD as local date for display
   const [yr, mo, dy] = dateKey.split('-').map(Number);
   const d = new Date(yr, mo - 1, dy);
   return d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
-function groupEntriesByDate(entries) {
+function groupActivityByDate(items) {
   const groups = new Map();
-  for (const e of entries) {
-    // logged_at is UTC from DB; take the local-date key for grouping
-    const raw = e.logged_at || '';
-    const iso = raw.includes('T') || raw.includes('Z') ? raw : raw.replace(' ', 'T') + 'Z';
-    const d = new Date(iso);
-    const key = Number.isNaN(d.getTime())
-      ? 'unknown'
-      : `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  for (const it of items) {
+    // Prefer the server's explicit `date` (canonical local day), but fall
+    // back to parsing occurred_at if missing.
+    let key = it.date;
+    if (!key) {
+      const raw = it.occurred_at || '';
+      const iso = raw.includes('T') || raw.includes('Z') ? raw : raw.replace(' ', 'T') + 'Z';
+      const d = new Date(iso);
+      key = Number.isNaN(d.getTime())
+        ? 'unknown'
+        : `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    }
     if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(e);
+    groups.get(key).push(it);
   }
   return Array.from(groups.entries())
-    .map(([date, items]) => ({ date, items }))
+    .map(([date, list]) => ({ date, items: list }))
     .sort((a, b) => (a.date < b.date ? 1 : -1));
 }
 
-function renderEntriesBody(entries) {
-  if (!entries || entries.length === 0) {
+function renderEntryRow(entry) {
+  const meta = ENTRY_TYPE_META[entry.entry_type] || {
+    icon: 'fa-pen', color: 'var(--color-text-muted)', label: entry.entry_type || 'Entry'
+  };
+  return html`
+    <div class="nutrition-entry-row">
+      <div class="nutrition-entry-icon" style="background: ${meta.color}20; color: ${meta.color};">
+        <i class="fas ${meta.icon}"></i>
+      </div>
+      <div style="flex: 1; min-width: 0;">
+        <strong>${meta.label}</strong>
+        <div class="text-muted" style="font-size: var(--text-xs);">
+          ${Math.round((Number(entry.amount) || 0) * 10) / 10}${entry.unit || ''}
+          · ${formatEntryTime(entry.occurred_at)}
+          ${entry.notes ? ` · ${entry.notes}` : ''}
+        </div>
+      </div>
+      <button class="btn btn-ghost btn-icon btn-sm text-danger"
+              data-delete-kind="entry" data-delete-id="${entry.id}" title="Delete entry">
+        <i class="fas fa-trash"></i>
+      </button>
+    </div>
+  `;
+}
+
+function renderMealRow(meal) {
+  const meta = mealMeta(meal.meal_type);
+  const t = meal.totals || {};
+  const macroBits = [
+    Number(t.calories) ? `${Math.round(t.calories)} cal` : null,
+    Number(t.protein_g) ? `${Math.round(t.protein_g)}g P` : null,
+    Number(t.carbs_g) ? `${Math.round(t.carbs_g)}g C` : null,
+    Number(t.fat_g) ? `${Math.round(t.fat_g)}g F` : null
+  ].filter(Boolean).join(' · ');
+  const foodBit = meal.food_count
+    ? `${meal.food_count} item${meal.food_count === 1 ? '' : 's'}`
+    : 'No items';
+  const timeBit = formatEntryTime(meal.occurred_at);
+
+  return html`
+    <div class="nutrition-entry-row">
+      <div class="nutrition-entry-icon" style="background: ${meta.color}20; color: ${meta.color};">
+        <i class="fas ${meta.icon}"></i>
+      </div>
+      <div style="flex: 1; min-width: 0;">
+        <strong>${meal.name || meta.label}</strong>
+        <div class="text-muted" style="font-size: var(--text-xs);">
+          ${macroBits || foodBit}${timeBit ? ` · ${timeBit}` : ''}${meal.name && meal.meal_type ? ` · ${meta.label}` : ''}
+          ${meal.notes ? ` · ${meal.notes}` : ''}
+        </div>
+      </div>
+      <button class="btn btn-ghost btn-icon btn-sm text-danger"
+              data-delete-kind="meal" data-delete-id="${meal.id}" title="Delete meal">
+        <i class="fas fa-trash"></i>
+      </button>
+    </div>
+  `;
+}
+
+function renderActivityBody(items) {
+  if (!items || items.length === 0) {
     return html`
       <div class="empty-state" style="padding: var(--space-8) var(--space-4);">
         <div class="empty-state-icon">🍽️</div>
         <div class="empty-state-title">No entries yet</div>
         <div class="empty-state-description">
-          Log protein, water, or creatine and it'll appear here.
+          Log protein, water, creatine, or a meal and it'll appear here.
         </div>
       </div>
     `;
   }
 
   const today = new Date().toISOString().split('T')[0];
-  const groups = groupEntriesByDate(entries);
+  const groups = groupActivityByDate(items);
 
   return html`
     <div class="stack stack-md" style="max-height: 500px; overflow-y: auto;">
       ${groups.map((group) => {
-        const totals = group.items.reduce((acc, e) => {
-          acc[e.entry_type] = (acc[e.entry_type] || 0) + (Number(e.amount) || 0);
+        const totals = group.items.reduce((acc, it) => {
+          if (it.kind === 'entry') {
+            acc[it.entry_type] = (acc[it.entry_type] || 0) + (Number(it.amount) || 0);
+          } else if (it.kind === 'meal' && it.totals) {
+            acc.calories = (acc.calories || 0) + (Number(it.totals.calories) || 0);
+            acc.protein = (acc.protein || 0) + (Number(it.totals.protein_g) || 0);
+          }
           return acc;
         }, {});
+        const summary = [
+          totals.calories ? `${Math.round(totals.calories)} cal` : null,
+          totals.protein ? `${Math.round(totals.protein)}g P` : null,
+          totals.water ? `${Math.round(totals.water)}ml W` : null,
+          totals.creatine ? `${Math.round(totals.creatine * 10) / 10}g C` : null
+        ].filter(Boolean).join(' · ');
         return html`
           <div>
             <div class="nutrition-entries-group-header">
               <strong>${formatEntryDateHeader(group.date, today)}</strong>
-              <span class="text-muted" style="font-size: var(--text-xs);">
-                ${totals.protein ? `${Math.round(totals.protein)}g P` : ''}
-                ${totals.water ? ` · ${Math.round(totals.water)}ml W` : ''}
-                ${totals.creatine ? ` · ${Math.round(totals.creatine * 10) / 10}g C` : ''}
-              </span>
+              <span class="text-muted" style="font-size: var(--text-xs);">${summary}</span>
             </div>
             <div class="stack stack-sm">
-              ${group.items.map((e) => {
-                const meta = ENTRY_TYPE_META[e.entry_type] || {
-                  icon: 'fa-utensils', color: 'var(--color-text-muted)', label: e.entry_type
-                };
-                return html`
-                  <div class="nutrition-entry-row">
-                    <div class="nutrition-entry-icon" style="background: ${meta.color}20; color: ${meta.color};">
-                      <i class="fas ${meta.icon}"></i>
-                    </div>
-                    <div style="flex: 1; min-width: 0;">
-                      <strong>${meta.label}</strong>
-                      <div class="text-muted" style="font-size: var(--text-xs);">
-                        ${Math.round((Number(e.amount) || 0) * 10) / 10}${e.unit || ''}
-                        · ${formatEntryTime(e.logged_at)}
-                        ${e.notes ? ` · ${e.notes}` : ''}
-                      </div>
-                    </div>
-                    <button class="btn btn-ghost btn-icon btn-sm text-danger"
-                            data-delete-entry="${e.id}" title="Delete entry">
-                      <i class="fas fa-trash"></i>
-                    </button>
-                  </div>
-                `;
-              })}
+              ${group.items.map((it) =>
+                it.kind === 'meal' ? renderMealRow(it) : renderEntryRow(it)
+              )}
             </div>
           </div>
         `;
       })}
     </div>
   `;
+}
+
+async function fetchActivityItems(start, end) {
+  const data = await api.get(
+    `/nutrition/activity?start_date=${start}&end_date=${end}`
+  );
+  return Array.isArray(data?.items) ? data.items : [];
 }
 
 export async function loadNutritionEntries() {
@@ -593,43 +660,49 @@ export async function loadNutritionEntries() {
   const start = startDate.toISOString().split('T')[0];
   const end = endDate.toISOString().split('T')[0];
 
-  let data;
+  let items;
   try {
-    data = await api.get(
-      `/nutrition/entries?start_date=${start}&end_date=${end}`
-    );
+    items = await fetchActivityItems(start, end);
   } catch (err) {
     toast.error(`Couldn't load entries: ${err.message}`);
     return;
   }
 
-  const entries = Array.isArray(data?.entries) ? data.entries : [];
-
   const api_ = openModal({
     title: 'Nutrition Entries (Last 14 Days)',
     size: 'default',
-    content: String(renderEntriesBody(entries)),
+    content: String(renderActivityBody(items)),
     actions: [{ label: 'Close', variant: 'btn-outline' }],
     onOpen: ({ element }) => {
       element.addEventListener('click', async (event) => {
-        const btn = event.target.closest('[data-delete-entry]');
+        const btn = event.target.closest('[data-delete-kind]');
         if (!btn) return;
-        const id = parseInt(btn.getAttribute('data-delete-entry'), 10);
+        const kind = btn.getAttribute('data-delete-kind');
+        const id = parseInt(btn.getAttribute('data-delete-id'), 10);
         if (!id) return;
 
-        await deleteNutritionEntry(id);
-        // Re-fetch + re-render the modal body in place (don't close + reopen
-        // — that flashes the modal and resets scroll position).
         try {
-          const refreshed = await api.get(
-            `/nutrition/entries?start_date=${start}&end_date=${end}`
-          );
+          if (kind === 'meal') {
+            await api.delete(`/nutrition/meals/${id}`);
+          } else {
+            await api.delete(`/nutrition/entries/${id}`);
+          }
+          toast.success('Deleted');
+          if (typeof window.loadNutrition === 'function') window.loadNutrition();
+        } catch (err) {
+          toast.error(`Error: ${err.message}`);
+          return;
+        }
+
+        // Re-fetch + re-render in place so scroll/selection aren't lost.
+        try {
+          const refreshed = await fetchActivityItems(start, end);
           const body = element.querySelector('.modal-body');
           if (body) {
-            body.innerHTML = String(renderEntriesBody(refreshed?.entries || []));
+            body.innerHTML = String(renderActivityBody(refreshed));
           }
         } catch (err) {
-          console.warn('Failed to refresh entries list:', err);
+          console.warn('Failed to refresh activity list:', err);
           closeTopModal();
         }
       });

--- a/frontend/src/features/workout-calendar.js
+++ b/frontend/src/features/workout-calendar.js
@@ -58,9 +58,14 @@ function renderGrid() {
       ? `view-day`
       : (!isFuture ? `log-past` : null);
 
+    // NOTE: interpolated attributes must be wrapped in raw() or the html`…`
+    // tag will HTML-entity-escape the " characters, producing broken markup
+    // like data-action=&quot;view-day&quot; — which the parser then reads as
+    // an unquoted attribute whose value includes literal quotes. That silently
+    // breaks every click on a calendar day.
     cells.push(html`
       <div class="cal-cell ${hasWorkout ? 'has-workout' : ''} ${isToday ? 'is-today' : ''} ${isFuture ? 'is-future' : ''}"
-           ${action ? `data-action="${action}" data-date="${key}"` : ''}
+           ${action ? raw(`data-action="${action}" data-date="${key}"`) : ''}
            title="${hasWorkout ? 'View workouts' : (!isFuture ? 'Click to log a workout' : '')}">
         <div class="cal-day-num">${day}</div>
         ${hasWorkout

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -205,7 +205,7 @@ registerScreen('start-workout-day', 'startWorkoutDay', startWorkoutDay);
 registerScreen('export-center', 'openUnifiedExporter', openUnifiedExporter);
 registerScreen('export-center-alias', 'openReportBuilder', openUnifiedExporter);
 
-// Advanced Analytics (rendered into #advancedAnalyticsSection by Insights)
+// Advanced Analytics (opens as a wide modal on demand)
 registerScreen('advanced-analytics', 'loadAdvancedAnalytics', loadAdvancedAnalytics);
 registerScreen('ai-recs-generate', 'generateRecommendations', generateRecommendations);
 registerScreen('ai-recs-apply', 'applyRecommendation', applyRecommendation);

--- a/src/routes/nutrition.js
+++ b/src/routes/nutrition.js
@@ -646,6 +646,108 @@ nutrition.get('/entries', async (c) => {
   return c.json({ entries: entries.results || [] });
 });
 
+// ============================================================================
+// Combined nutrition activity feed (manual entries + logged meals)
+//
+// The Nutrition Entries modal in the UI wants a single chronological list of
+// every nutrition-related thing the user logged: manual protein/water/creatine
+// entries AND full meals (which can come from meal-logger, AI parsing, saved
+// meal templates, or barcode scans). `/entries` alone only returns the first
+// kind, so the modal used to silently omit meals.
+//
+// Response shape is a flat `items[]` array with a `kind` discriminator so the
+// frontend can render each row uniformly. Meals are rolled up to totals per
+// meal (single GROUP BY query, no N+1 per-meal food fetch).
+// ============================================================================
+nutrition.get('/activity', async (c) => {
+  const user = requireAuth(c);
+  const db = c.env.DB;
+  const today = new Date().toISOString().split('T')[0];
+  const defaultStart = new Date(Date.now() - 13 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const startDate = c.req.query('start_date') || defaultStart;
+  const endDate = c.req.query('end_date') || today;
+
+  // Manual entries (protein / water / creatine)
+  const entriesResult = await db.prepare(
+    `SELECT id, entry_type, amount, unit, notes, logged_at
+       FROM nutrition_entries
+      WHERE user_id = ?
+        AND date(logged_at) >= ?
+        AND date(logged_at) <= ?
+      ORDER BY logged_at DESC`
+  ).bind(user.id, startDate, endDate).all();
+
+  // Meals with rolled-up macros from meal_foods (single query, no N+1).
+  // NULL food rows (bare meals added via AI parsing or saved-meal templates
+  // that carried no ingredient rows) still return a meal row with 0 food_count
+  // — the client needs to display them too.
+  const mealsResult = await db.prepare(
+    `SELECT m.id,
+            m.date,
+            m.meal_type,
+            m.name,
+            m.notes,
+            m.created_at,
+            COUNT(mf.id)                   AS food_count,
+            COALESCE(SUM(mf.calories), 0)  AS calories,
+            COALESCE(SUM(mf.protein_g), 0) AS protein_g,
+            COALESCE(SUM(mf.carbs_g), 0)   AS carbs_g,
+            COALESCE(SUM(mf.fat_g), 0)     AS fat_g
+       FROM meals m
+       LEFT JOIN meal_foods mf ON mf.meal_id = m.id
+      WHERE m.user_id = ?
+        AND m.date >= ?
+        AND m.date <= ?
+      GROUP BY m.id
+      ORDER BY m.date DESC, m.created_at DESC`
+  ).bind(user.id, startDate, endDate).all();
+
+  const entries = (entriesResult.results || []).map((e) => ({
+    kind: 'entry',
+    id: e.id,
+    date: (e.logged_at || '').split(/[T ]/)[0] || null,
+    occurred_at: e.logged_at,
+    entry_type: e.entry_type,
+    amount: e.amount,
+    unit: e.unit,
+    notes: e.notes
+  }));
+
+  const meals = (mealsResult.results || []).map((m) => ({
+    kind: 'meal',
+    id: m.id,
+    date: m.date,
+    occurred_at: m.created_at,
+    meal_type: m.meal_type || 'snack',
+    name: m.name || null,
+    food_count: m.food_count || 0,
+    notes: m.notes,
+    totals: {
+      calories: Math.round(m.calories || 0),
+      protein_g: Math.round((m.protein_g || 0) * 10) / 10,
+      carbs_g: Math.round((m.carbs_g || 0) * 10) / 10,
+      fat_g: Math.round((m.fat_g || 0) * 10) / 10
+    }
+  }));
+
+  // Merge + sort by occurred_at DESC. `occurred_at` may be an ISO string
+  // with T/Z or a SQLite "YYYY-MM-DD HH:MM:SS" string — normalize with
+  // Date.parse, falling back to string compare.
+  const ts = (s) => {
+    if (!s) return 0;
+    const norm = s.includes('T') || s.includes('Z') ? s : s.replace(' ', 'T') + 'Z';
+    const t = Date.parse(norm);
+    return Number.isNaN(t) ? 0 : t;
+  };
+  const items = [...entries, ...meals].sort((a, b) => ts(b.occurred_at) - ts(a.occurred_at));
+
+  return c.json({
+    start_date: startDate,
+    end_date: endDate,
+    items
+  });
+});
+
 // Update nutrition entry
 nutrition.put('/entries/:id', async (c) => {
   const user = requireAuth(c);


### PR DESCRIPTION
## Summary

Three regressions from testing, each with a different root cause:

1. **AI Fitness Coach "Full Analysis"** opened an empty modal — frontend read `response.data` but backend returns `response.analysis`.
2. **AI Fitness Coach "Advanced Analytics"** did nothing — early-returned because `#advancedAnalyticsSection` mount element is never created by the migrated Insights screen.
3. **Stats → Workout Calendar** day clicks silently dropped — interpolated `data-action` attributes were HTML-entity-escaped (`data-action=&quot;view-day&quot;`), so the switch statement never matched a case.
4. **Nutrition Entries modal** only showed protein/water/creatine — meals logged via meal-logger / barcode / AI parser / saved-meal templates live in a different table and weren't being fetched.

## Fixes

### 1. Full Analysis — read the right response field + handle all shapes

`frontend/src/features/ai-coach/coaching-modals.js`

The backend (`src/services/ai-coach.js:479-493`) can return four distinct response shapes:

| Shape | Handling |
|---|---|
| `{ success: true, analysis: {…} }` | Render the 4-section analysis (now 7 sections) |
| `{ success: true, parsing_failed: true, raw_response: "…" }` | Render raw model text |
| `{ success: false, message: "Need ≥3 workouts…" }` | Friendly empty state |
| `{ success: false, error: "…" }` | Toast + log |

The rewrite handles all four. Also surfaces `areas_for_improvement`, `next_workout_tips`, and `weekly_focus` fields (the backend was producing them; the UI was silently ignoring them). Recommendations now render their `action_steps[]` array and `expected_outcome` string.

### 2. Advanced Analytics — make it a modal

`frontend/src/features/analytics/advanced-analytics.js`

`loadAdvancedAnalytics()` was keyed to a DOM element that doesn't exist. Refactored to `openModal({ size: 'wide', content: … })` using the same render helpers it already had. Works from any tab, matches the Full Analysis button pattern, handles empty-data state.

### 3. Workout Calendar — `raw()` the attributes

`frontend/src/features/workout-calendar.js:63`

One-line fix: `${action ? \`data-action="${action}" data-date="${key}"\` : ''}` → `${action ? raw(\`data-action="${action}" data-date="${key}"\`) : ''}`. Added a comment explaining why, so nobody "simplifies" it back later. Fixes both `view-day` (click a workout day) and `log-past` (click an empty past day) actions.

### 4. Nutrition Entries modal — unified activity feed

**New backend endpoint:** `GET /nutrition/activity?start_date=&end_date=`

Returns a flat, chronological `items[]` array merging:
- Manual entries from `nutrition_entries` (protein/water/creatine)
- Logged meals from `meals` with per-meal macros rolled up via `COUNT(mf.id) AS food_count, SUM(mf.calories, mf.protein_g, mf.carbs_g, mf.fat_g)` + `GROUP BY m.id` — single query, no N+1.

Each item has a `kind: 'entry' | 'meal'` discriminator so the client can render uniformly. Server-side sort by `occurred_at DESC` with a timestamp-normalizer that handles both ISO and SQLite timestamp formats.

**Modal updates** (`saved-meals.js`):
- Fetches `/nutrition/activity` (14-day window) instead of `/nutrition/entries`
- Meal rows show a meal-type icon (🌞 breakfast / 🍴 lunch / 🌙 dinner / 🍪 snack), rolled-up macros (`420 cal · 35g P · 40g C · 12g F`), name if set, meal type label, food count, and time
- Per-day group header now includes calories alongside existing protein/water/creatine subtotals
- Delete button uses `data-delete-kind` + `data-delete-id` and routes to `/meals/:id` or `/entries/:id`
- Empty-state copy updated to mention meals

No DB migration — all tables already exist.

## Verification

- `npm test` — **111 / 111 pass**
- `npx wrangler deploy --dry-run` — clean, 381 KiB / 79 KiB gzipped
- Workout-calendar click fix is covered by existing `html.test.js` "does not escape raw() values" regression test

## Files changed

- `src/routes/nutrition.js` — new `GET /activity` endpoint (+102 lines)
- `frontend/src/features/ai-coach/coaching-modals.js` — rewrote `generateAICoaching()` (+150, -75)
- `frontend/src/features/analytics/advanced-analytics.js` — rewrote `loadAdvancedAnalytics()` as modal (+70, -40)
- `frontend/src/features/workout-calendar.js` — one-line `raw()` fix + comment
- `frontend/src/features/nutrition/saved-meals.js` — rewrote entries modal to consume activity feed
- `frontend/src/main.js` — updated comment on advanced-analytics registration