### PR TITLE
Rebuild nutrition ledger + fix standalone barcode logging

### DIFF
--- a/frontend/src/features/nutrition/meal-logger.js
+++ b/frontend/src/features/nutrition/meal-logger.js
@@ -707,6 +707,27 @@ function stopBarcodeScanner() {
   }
 }
 
+// Auto-detect a reasonable meal type based on local time of day.
+// Used as the default when the barcode scanner is opened standalone
+// (no parent meal-logger modal carrying an explicit meal type).
+function autoMealTypeByTime(date = new Date()) {
+  const h = date.getHours();
+  if (h >= 4 && h < 11) return 'breakfast';
+  if (h >= 11 && h < 15) return 'lunch';
+  if (h >= 17 && h < 21) return 'dinner';
+  return 'snack';
+}
+
+// Ensure a scanned food has an id in our `foods` table. The barcode
+// endpoint already UPSERTs, so `food.id` is almost always set — but
+// fall back to POST /nutrition/foods if a caller somehow loses it.
+async function ensureFoodPersisted(food) {
+  if (food && food.id) return food;
+  if (!food) throw new Error('No food data to save');
+  const saved = await api.post('/nutrition/foods', food);
+  return saved.food;
+}
+
 async function lookupBarcode() {
   const input = document.getElementById('manual-barcode');
   const barcode = input?.value?.trim();
@@ -744,40 +765,127 @@ async function lookupBarcode() {
       return;
     }
 
-    if (resultEl) {
-      resultEl.innerHTML = String(html`
-        <div class="card card-sunken">
-          <h3>${food.name}</h3>
-          ${food.brand ? html`<p class="text-muted" style="font-size: var(--text-sm);">${food.brand}</p>` : ''}
-          <div class="barcode-macros">
-            <div><strong>${Math.round(food.calories || 0)}</strong><br><span class="text-muted">cal</span></div>
-            <div class="text-success"><strong>${(food.protein_g || 0).toFixed(1)}g</strong><br><span class="text-muted">P</span></div>
-            <div class="text-primary"><strong>${(food.carbs_g || 0).toFixed(1)}g</strong><br><span class="text-muted">C</span></div>
-            <div class="text-warning"><strong>${(food.fat_g || 0).toFixed(1)}g</strong><br><span class="text-muted">F</span></div>
-          </div>
-          <button class="btn btn-primary btn-block" id="add-scanned-food">
-            <i class="fas fa-plus"></i> Add to Meal
-          </button>
-        </div>
-      `);
+    // Detect whether the scanner was opened from inside the meal-logger
+    // modal (Path A) or standalone from the Nutrition screen (Path B).
+    // Path B used to silently do nothing after a scan — now it lets the
+    // user log the food immediately, save it to favorites, or promote
+    // the scan into a full meal builder.
+    const isInMealLogger = !!document.getElementById('meal-selected-foods');
+    const defaultMealType = isInMealLogger ? state.mealType : autoMealTypeByTime();
 
+    if (!resultEl) return;
+
+    resultEl.innerHTML = String(html`
+      <div class="card card-sunken">
+        <h3>${food.name}</h3>
+        ${food.brand ? html`<p class="text-muted" style="font-size: var(--text-sm);">${food.brand}</p>` : ''}
+        <div class="barcode-macros">
+          <div><strong>${Math.round(food.calories || 0)}</strong><br><span class="text-muted">cal</span></div>
+          <div class="text-success"><strong>${(food.protein_g || 0).toFixed(1)}g</strong><br><span class="text-muted">P</span></div>
+          <div class="text-primary"><strong>${(food.carbs_g || 0).toFixed(1)}g</strong><br><span class="text-muted">C</span></div>
+          <div class="text-warning"><strong>${(food.fat_g || 0).toFixed(1)}g</strong><br><span class="text-muted">F</span></div>
+        </div>
+
+        ${isInMealLogger
+          ? html`
+              <button class="btn btn-primary btn-block" id="add-scanned-food">
+                <i class="fas fa-plus"></i> Add to Meal
+              </button>
+            `
+          : html`
+              <div class="barcode-log-controls">
+                <label class="form-label" style="margin: 0;">Quantity</label>
+                <input type="number" id="scan-qty" class="input"
+                       min="0.25" step="0.25" value="1"
+                       style="max-width: 6rem;" />
+                <label class="form-label" style="margin: 0;">Meal</label>
+                <select id="scan-meal-type" class="input" style="flex: 1; min-width: 8rem;">
+                  <option value="breakfast" ${defaultMealType === 'breakfast' ? 'selected' : ''}>Breakfast</option>
+                  <option value="lunch" ${defaultMealType === 'lunch' ? 'selected' : ''}>Lunch</option>
+                  <option value="dinner" ${defaultMealType === 'dinner' ? 'selected' : ''}>Dinner</option>
+                  <option value="snack" ${defaultMealType === 'snack' ? 'selected' : ''}>Snack</option>
+                </select>
+              </div>
+              <div class="cluster" style="margin-top: var(--space-3);">
+                <button class="btn btn-primary" id="scan-log-now" style="flex: 1;">
+                  <i class="fas fa-check"></i> Log It
+                </button>
+                <button class="btn btn-outline" id="scan-save-favorite" title="Save this food to your Favorites">
+                  <i class="far fa-star"></i> Save
+                </button>
+              </div>
+              <button class="btn btn-ghost btn-sm btn-block" id="scan-build-meal"
+                      style="margin-top: var(--space-2);">
+                <i class="fas fa-utensils"></i> Build a full meal with this
+              </button>
+            `}
+      </div>
+    `);
+
+    if (isInMealLogger) {
+      // Legacy path: add to the open meal-logger's selection buffer.
       document.getElementById('add-scanned-food')?.addEventListener('click', async () => {
-        let toAdd = food;
-        if (!toAdd.id && toAdd.source) {
-          try {
-            const saved = await api.post('/nutrition/foods', toAdd);
-            toAdd = saved.food;
-          } catch (err) {
-            toast.error(`Error saving food: ${err.message}`);
-            return;
-          }
+        try {
+          const toAdd = await ensureFoodPersisted(food);
+          state.selectedFoods.push({ food_id: toAdd.id, food: toAdd, quantity: 1, unit: 'serving' });
+          closeTopModal();
+          updateSelectedFoodsDisplay();
+          toast.success(`Added ${toAdd.name}`);
+        } catch (err) {
+          toast.error(`Error: ${err.message}`);
         }
+      });
+      return;
+    }
+
+    // Standalone path: three actions.
+
+    // 1) Log It — quick-add a single-food meal to today in the chosen meal slot.
+    document.getElementById('scan-log-now')?.addEventListener('click', async () => {
+      const qty = parseFloat(document.getElementById('scan-qty')?.value) || 1;
+      const mealType = document.getElementById('scan-meal-type')?.value || defaultMealType;
+      try {
+        const toAdd = await ensureFoodPersisted(food);
+        await api.post('/nutrition/quick-add', {
+          food_id: toAdd.id,
+          quantity: qty,
+          unit: 'serving',
+          meal_type: mealType
+        });
+        closeTopModal();
+        toast.success(`Logged ${toAdd.name}`);
+        if (typeof window.loadNutrition === 'function') window.loadNutrition();
+      } catch (err) {
+        toast.error(`Error logging food: ${err.message}`);
+      }
+    });
+
+    // 2) Save — toggle the food as a user favorite so it shows up in the
+    //    Favorites list on future meal logs, without creating a meal entry.
+    document.getElementById('scan-save-favorite')?.addEventListener('click', async () => {
+      try {
+        const toAdd = await ensureFoodPersisted(food);
+        const res = await api.post(`/nutrition/foods/${toAdd.id}/favorite`);
+        toast.success(res?.is_favorite ? 'Saved to Favorites' : 'Removed from Favorites');
+      } catch (err) {
+        toast.error(`Error: ${err.message}`);
+      }
+    });
+
+    // 3) Build a full meal — close the scanner, open the meal logger with
+    //    this food pre-loaded so the user can keep adding items and save
+    //    one combined meal.
+    document.getElementById('scan-build-meal')?.addEventListener('click', async () => {
+      try {
+        const toAdd = await ensureFoodPersisted(food);
+        const mealType = document.getElementById('scan-meal-type')?.value || defaultMealType;
         state.selectedFoods.push({ food_id: toAdd.id, food: toAdd, quantity: 1, unit: 'serving' });
         closeTopModal();
-        updateSelectedFoodsDisplay();
-        toast.success(`Added ${toAdd.name}`);
-      });
-    }
+        await showLogMealModal(mealType, /* preserveFoods */ true);
+      } catch (err) {
+        toast.error(`Error: ${err.message}`);
+      }
+    });
   } catch (err) {
     if (resultEl) resultEl.innerHTML = `<div class="empty-state"><div class="empty-state-description text-danger">${err.message}</div></div>`;
   }

--- a/migrations/0028_meals_macros_cache.sql
+++ b/migrations/0028_meals_macros_cache.sql
@@ -1,0 +1,40 @@
+-- Migration 0028: Cache per-meal macro totals on the `meals` row.
+--
+-- Prior architecture: macros lived only on child `meal_foods` rows, so
+-- reading a meal's totals required SUM over the join. That also meant
+-- "macro-only" meals (saved-meal logs where saved_meal_foods was empty,
+-- or /meals POSTs that sent `custom_macros` instead of a foods[] list)
+-- had NO macro source at all — the meal existed on the Nutrition
+-- screen as a row but the /activity feed showed "0 cal, 0g P, 0g C, 0g F".
+--
+-- After this migration:
+--  - `meals.calories`, `meals.protein_g`, `meals.carbs_g`, `meals.fat_g`,
+--    `meals.fiber_g` are the single source of truth for a meal's totals.
+--  - Every endpoint that creates or mutates a meal maintains these columns.
+--  - DELETE /meals/:id reads them to subtract from nutrition_log.
+--  - GET /activity reads them directly (no N+1 rollup).
+--
+-- Backfill strategy: any meal whose totals aren't yet set gets the
+-- SUM from its `meal_foods` children. Meals with no children stay at 0
+-- (they were already 0 under the old rollup — this preserves that
+-- behavior until a future write path populates them).
+
+ALTER TABLE meals ADD COLUMN calories  REAL NOT NULL DEFAULT 0;
+ALTER TABLE meals ADD COLUMN protein_g REAL NOT NULL DEFAULT 0;
+ALTER TABLE meals ADD COLUMN carbs_g   REAL NOT NULL DEFAULT 0;
+ALTER TABLE meals ADD COLUMN fat_g     REAL NOT NULL DEFAULT 0;
+ALTER TABLE meals ADD COLUMN fiber_g   REAL NOT NULL DEFAULT 0;
+
+-- Backfill from meal_foods. COALESCE handles meals with no food rows.
+UPDATE meals SET
+  calories  = COALESCE((SELECT SUM(mf.calories)  FROM meal_foods mf WHERE mf.meal_id = meals.id), 0),
+  protein_g = COALESCE((SELECT SUM(mf.protein_g) FROM meal_foods mf WHERE mf.meal_id = meals.id), 0),
+  carbs_g   = COALESCE((SELECT SUM(mf.carbs_g)   FROM meal_foods mf WHERE mf.meal_id = meals.id), 0),
+  fat_g     = COALESCE((SELECT SUM(mf.fat_g)     FROM meal_foods mf WHERE mf.meal_id = meals.id), 0);
+-- fiber is not tracked on meal_foods (by design), so leave at 0.
+
+-- Helpful index for the /activity feed which filters by (user_id, date) and
+-- orders by created_at. The existing (user_id, date, meal_type) index at
+-- migration 0026 doesn't cover date-range scans with created_at ordering.
+CREATE INDEX IF NOT EXISTS idx_meals_user_date_created
+  ON meals(user_id, date, created_at DESC);

--- a/src/routes/nutrition.js
+++ b/src/routes/nutrition.js
@@ -1,5 +1,16 @@
 import { Hono } from 'hono';
 import { requireAuth } from '../middleware/auth';
+import {
+  normalizeMacros,
+  sumMacros,
+  setMealTotals,
+  recomputeMealTotals,
+  addToNutritionLog,
+  subtractFromNutritionLog,
+  addEntryToLog,
+  subtractEntryFromLog,
+  entryColumnFor
+} from '../utils/nutrition-ledger';
 
 const nutrition = new Hono();
 
@@ -595,6 +606,7 @@ nutrition.post('/entries', async (c) => {
   }
 
   const timestamp = logged_at || new Date().toISOString();
+  const logDate = timestamp.split(/[T ]/)[0];
 
   const result = await db.prepare(
     `INSERT INTO nutrition_entries (user_id, entry_type, amount, unit, notes, logged_at)
@@ -602,18 +614,7 @@ nutrition.post('/entries', async (c) => {
      RETURNING *`
   ).bind(user.id, entry_type, amount, unit, notes || null, timestamp).first();
 
-  // Also update the daily summary for backward compatibility
-  const logDate = timestamp.split('T')[0];
-  const column = entry_type === 'protein' ? 'protein_grams' : entry_type === 'water' ? 'water_ml' : 'creatine_grams';
-  
-  await db.prepare(
-    `INSERT INTO nutrition_log (user_id, date, ${column}, updated_at)
-     VALUES (?, ?, ?, CURRENT_TIMESTAMP)
-     ON CONFLICT(user_id, date) 
-     DO UPDATE SET 
-       ${column} = ${column} + excluded.${column},
-       updated_at = CURRENT_TIMESTAMP`
-  ).bind(user.id, logDate, amount).run();
+  await addEntryToLog(db, user.id, logDate, entry_type, amount);
 
   return c.json({ entry: result, message: 'Entry added' });
 });
@@ -677,10 +678,14 @@ nutrition.get('/activity', async (c) => {
       ORDER BY logged_at DESC`
   ).bind(user.id, startDate, endDate).all();
 
-  // Meals with rolled-up macros from meal_foods (single query, no N+1).
-  // NULL food rows (bare meals added via AI parsing or saved-meal templates
-  // that carried no ingredient rows) still return a meal row with 0 food_count
-  // — the client needs to display them too.
+  // Meals — read the CACHED per-meal totals from the meals row (migration
+  // 0028) instead of SUMming meal_foods. This fixes the "saved meal logs
+  // show 0 macros" bug, because saved meals can have zero meal_foods rows
+  // but still carry their macros on the meal row. Also O(1) per meal, no
+  // N+1.
+  //
+  // `food_count` is still rolled up so the UI can show "3 items" vs
+  // "No items" hints.
   const mealsResult = await db.prepare(
     `SELECT m.id,
             m.date,
@@ -688,17 +693,16 @@ nutrition.get('/activity', async (c) => {
             m.name,
             m.notes,
             m.created_at,
-            COUNT(mf.id)                   AS food_count,
-            COALESCE(SUM(mf.calories), 0)  AS calories,
-            COALESCE(SUM(mf.protein_g), 0) AS protein_g,
-            COALESCE(SUM(mf.carbs_g), 0)   AS carbs_g,
-            COALESCE(SUM(mf.fat_g), 0)     AS fat_g
+            m.calories,
+            m.protein_g,
+            m.carbs_g,
+            m.fat_g,
+            m.fiber_g,
+            (SELECT COUNT(*) FROM meal_foods mf WHERE mf.meal_id = m.id) AS food_count
        FROM meals m
-       LEFT JOIN meal_foods mf ON mf.meal_id = m.id
       WHERE m.user_id = ?
         AND m.date >= ?
         AND m.date <= ?
-      GROUP BY m.id
       ORDER BY m.date DESC, m.created_at DESC`
   ).bind(user.id, startDate, endDate).all();
 
@@ -722,12 +726,13 @@ nutrition.get('/activity', async (c) => {
     name: m.name || null,
     food_count: m.food_count || 0,
     notes: m.notes,
-    totals: {
-      calories: Math.round(m.calories || 0),
-      protein_g: Math.round((m.protein_g || 0) * 10) / 10,
-      carbs_g: Math.round((m.carbs_g || 0) * 10) / 10,
-      fat_g: Math.round((m.fat_g || 0) * 10) / 10
-    }
+    totals: normalizeMacros({
+      calories: m.calories,
+      protein_g: m.protein_g,
+      carbs_g: m.carbs_g,
+      fat_g: m.fat_g,
+      fiber_g: m.fiber_g
+    })
   }));
 
   // Merge + sort by occurred_at DESC. `occurred_at` may be an ISO string
@@ -749,6 +754,11 @@ nutrition.get('/activity', async (c) => {
 });
 
 // Update nutrition entry
+//
+// If the amount OR the logged_at date changes, rebalance nutrition_log
+// on BOTH days: fully reverse the old amount from the old day, then add
+// the new amount to the new day. Previously this only adjusted the new
+// day's log, leaving the old day permanently inflated on date changes.
 nutrition.put('/entries/:id', async (c) => {
   const user = requireAuth(c);
   const entryId = c.req.param('id');
@@ -756,7 +766,6 @@ nutrition.put('/entries/:id', async (c) => {
   const { amount, notes, logged_at } = body;
   const db = c.env.DB;
 
-  // Verify ownership
   const existing = await db.prepare(
     'SELECT * FROM nutrition_entries WHERE id = ? AND user_id = ?'
   ).bind(entryId, user.id).first();
@@ -765,31 +774,33 @@ nutrition.put('/entries/:id', async (c) => {
     return c.json({ error: 'Entry not found' }, 404);
   }
 
-  const oldAmount = existing.amount;
-  const newAmount = amount !== undefined ? amount : existing.amount;
+  const oldAmount = Number(existing.amount) || 0;
+  const oldDate = (existing.logged_at || '').split(/[T ]/)[0];
+
+  const newAmount = amount !== undefined ? Number(amount) || 0 : oldAmount;
   const newNotes = notes !== undefined ? notes : existing.notes;
   const newLoggedAt = logged_at || existing.logged_at;
+  const newDate = (newLoggedAt || '').split(/[T ]/)[0];
 
-  // Update entry
   const updated = await db.prepare(
-    `UPDATE nutrition_entries 
-     SET amount = ?, notes = ?, logged_at = ?
-     WHERE id = ? AND user_id = ?
-     RETURNING *`
+    `UPDATE nutrition_entries
+        SET amount = ?, notes = ?, logged_at = ?
+      WHERE id = ? AND user_id = ?
+      RETURNING *`
   ).bind(newAmount, newNotes, newLoggedAt, entryId, user.id).first();
 
-  // Update daily summary (adjust the difference)
-  const logDate = newLoggedAt.split('T')[0];
-  const column = existing.entry_type === 'protein' ? 'protein_grams' : existing.entry_type === 'water' ? 'water_ml' : 'creatine_grams';
-  const amountDiff = newAmount - oldAmount;
-
-  if (amountDiff !== 0) {
-    await db.prepare(
-      `UPDATE nutrition_log 
-       SET ${column} = MAX(0, ${column} + ?),
-           updated_at = CURRENT_TIMESTAMP
-       WHERE user_id = ? AND date = ?`
-    ).bind(amountDiff, user.id, logDate).run();
+  if (oldDate === newDate) {
+    // Same day — adjust by the delta only.
+    const delta = newAmount - oldAmount;
+    if (delta > 0) {
+      await addEntryToLog(db, user.id, newDate, existing.entry_type, delta);
+    } else if (delta < 0) {
+      await subtractEntryFromLog(db, user.id, newDate, existing.entry_type, -delta);
+    }
+  } else {
+    // Date moved — fully reverse old day, fully add to new day.
+    await subtractEntryFromLog(db, user.id, oldDate, existing.entry_type, oldAmount);
+    await addEntryToLog(db, user.id, newDate, existing.entry_type, newAmount);
   }
 
   return c.json({ entry: updated, message: 'Entry updated' });
@@ -801,7 +812,6 @@ nutrition.delete('/entries/:id', async (c) => {
   const entryId = c.req.param('id');
   const db = c.env.DB;
 
-  // Get entry to adjust daily summary
   const entry = await db.prepare(
     'SELECT * FROM nutrition_entries WHERE id = ? AND user_id = ?'
   ).bind(entryId, user.id).first();
@@ -810,21 +820,12 @@ nutrition.delete('/entries/:id', async (c) => {
     return c.json({ error: 'Entry not found' }, 404);
   }
 
-  // Delete entry
   await db.prepare(
     'DELETE FROM nutrition_entries WHERE id = ? AND user_id = ?'
   ).bind(entryId, user.id).run();
 
-  // Update daily summary (subtract the amount)
-  const logDate = entry.logged_at.split('T')[0];
-  const column = entry.entry_type === 'protein' ? 'protein_grams' : entry.entry_type === 'water' ? 'water_ml' : 'creatine_grams';
-
-  await db.prepare(
-    `UPDATE nutrition_log 
-     SET ${column} = MAX(0, ${column} - ?),
-         updated_at = CURRENT_TIMESTAMP
-     WHERE user_id = ? AND date = ?`
-  ).bind(entry.amount, user.id, logDate).run();
+  const logDate = (entry.logged_at || '').split(/[T ]/)[0];
+  await subtractEntryFromLog(db, user.id, logDate, entry.entry_type, entry.amount);
 
   return c.json({ message: 'Entry deleted' });
 });
@@ -1497,29 +1498,36 @@ nutrition.post('/foods', async (c) => {
 });
 
 // Log a meal
+//
+// Accepts either a `foods[]` array (normal meal-logger save) or a
+// `custom_macros` object (Quick Macro Entry — user types the totals
+// directly without picking foods). In both cases the final macros are:
+//   - stored on the child meal_foods rows (when foods were provided)
+//   - cached on the meals row itself (so /activity and DELETE reads are O(1))
+//   - added to nutrition_log for the day (progress rings)
 nutrition.post('/meals', async (c) => {
   const user = requireAuth(c);
   const body = await c.req.json();
   const db = c.env.DB;
-  
-  const { date, meal_type, name, foods, notes } = body;
-  
+
+  const { date, meal_type, name, foods, notes, custom_macros } = body;
+
   const mealDate = date || new Date().toISOString().split('T')[0];
   const mealType = meal_type || 'snack';
-  
-  // Create meal
+
+  // Create meal (macros defaulted to 0; filled in below)
   const meal = await db.prepare(
     `INSERT INTO meals (user_id, date, meal_type, name, notes)
      VALUES (?, ?, ?, ?, ?)
      RETURNING *`
   ).bind(user.id, mealDate, mealType, name || null, notes || null).first();
-  
-  // Add foods to meal
-  let totalCalories = 0, totalProtein = 0, totalCarbs = 0, totalFat = 0, totalFiber = 0;
-  
-  if (foods && foods.length > 0) {
+
+  let totals = { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0 };
+
+  if (Array.isArray(foods) && foods.length > 0) {
     for (const item of foods) {
-      // Get food details
+      // Get food details — either by existing id or by UPSERTing an
+      // inline food payload (e.g. from USDA/OFF search results).
       let food;
       if (item.food_id) {
         food = await db.prepare('SELECT * FROM foods WHERE id = ?').bind(item.food_id).first();
@@ -1566,13 +1574,11 @@ nutrition.post('/meals', async (c) => {
       }
 
       if (!food) continue;
-      
+
       const quantity = item.quantity || 1;
       const unit = item.unit || 'serving';
-      
-      // Calculate macros
       const macros = calculateMacros(food, quantity, unit);
-      
+
       await db.prepare(
         `INSERT INTO meal_foods (meal_id, food_id, quantity, unit, calories, protein_g, carbs_g, fat_g, notes)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -1581,12 +1587,12 @@ nutrition.post('/meals', async (c) => {
         macros.calories, macros.protein_g, macros.carbs_g, macros.fat_g,
         item.notes || null
       ).run();
-      
-      totalCalories += macros.calories;
-      totalProtein += macros.protein_g;
-      totalCarbs += macros.carbs_g;
-      totalFat += macros.fat_g;
-      totalFiber += macros.fiber_g || 0;
+
+      totals.calories += macros.calories;
+      totals.protein_g += macros.protein_g;
+      totals.carbs_g += macros.carbs_g;
+      totals.fat_g += macros.fat_g;
+      totals.fiber_g += macros.fiber_g || 0;
 
       // Update user favorites/frequent foods
       await db.prepare(
@@ -1597,143 +1603,131 @@ nutrition.post('/meals', async (c) => {
            last_used = CURRENT_TIMESTAMP`
       ).bind(user.id, food.id).run();
     }
+  } else if (custom_macros && typeof custom_macros === 'object') {
+    // Quick Macro Entry path — no foods[], just raw macro numbers.
+    // Previously this silently dropped the macros (the handler only
+    // looked at foods[]) and created an empty meal row.
+    totals = {
+      calories:  Number(custom_macros.calories)  || 0,
+      protein_g: Number(custom_macros.protein_g ?? custom_macros.protein) || 0,
+      carbs_g:   Number(custom_macros.carbs_g   ?? custom_macros.carbs)   || 0,
+      fat_g:     Number(custom_macros.fat_g     ?? custom_macros.fat)     || 0,
+      fiber_g:   Number(custom_macros.fiber_g   ?? custom_macros.fiber)   || 0
+    };
   }
-  
-  // Also update daily nutrition log with the full macro breakdown so the
-  // Today's Nutrition rings + AI coach have a clean daily total to read.
-  await db.prepare(
-    `INSERT INTO nutrition_log
-       (user_id, date, calories, protein_grams, carbs_grams, fat_grams, fiber_grams, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-     ON CONFLICT(user_id, date) DO UPDATE SET
-       calories = COALESCE(calories, 0) + excluded.calories,
-       protein_grams = COALESCE(protein_grams, 0) + excluded.protein_grams,
-       carbs_grams = COALESCE(carbs_grams, 0) + excluded.carbs_grams,
-       fat_grams = COALESCE(fat_grams, 0) + excluded.fat_grams,
-       fiber_grams = COALESCE(fiber_grams, 0) + excluded.fiber_grams,
-       updated_at = CURRENT_TIMESTAMP`
-  ).bind(
-    user.id,
-    mealDate,
-    Math.round(totalCalories),
-    Math.round(totalProtein * 10) / 10,
-    Math.round(totalCarbs * 10) / 10,
-    Math.round(totalFat * 10) / 10,
-    Math.round(totalFiber * 10) / 10
-  ).run();
-  
+
+  // Cache the totals on the meals row — single source of truth for later
+  // reads (/activity, DELETE), so no JOIN/SUM is needed.
+  const cached = await setMealTotals(db, meal.id, totals);
+
+  // Update daily nutrition log so the Today's Nutrition rings + AI coach
+  // see the full macro breakdown.
+  await addToNutritionLog(db, user.id, mealDate, cached);
+
   return c.json({
     meal: {
       ...meal,
-      totals: {
-        calories: Math.round(totalCalories),
-        protein_g: Math.round(totalProtein * 10) / 10,
-        carbs_g: Math.round(totalCarbs * 10) / 10,
-        fat_g: Math.round(totalFat * 10) / 10
-      }
+      ...cached,
+      totals: cached
     },
     message: 'Meal logged'
   });
 });
 
 // Get meals for a date
+//
+// Returns every meal row for the day with its cached totals (from the
+// meals row, migration 0028) plus its child meal_foods for display. The
+// cached totals are the authoritative per-meal numbers — a saved-meal
+// log with no meal_foods children still shows its macros.
 nutrition.get('/meals', async (c) => {
   const user = requireAuth(c);
   const db = c.env.DB;
   const date = c.req.query('date') || new Date().toISOString().split('T')[0];
-  
+
   const meals = await db.prepare(
-    `SELECT m.*, 
-            GROUP_CONCAT(mf.id) as food_item_ids
-     FROM meals m
-     LEFT JOIN meal_foods mf ON m.id = mf.meal_id
-     WHERE m.user_id = ? AND m.date = ?
-     GROUP BY m.id
-     ORDER BY 
-       CASE m.meal_type 
-         WHEN 'breakfast' THEN 1 
-         WHEN 'lunch' THEN 2 
-         WHEN 'dinner' THEN 3 
-         WHEN 'snack' THEN 4 
-         ELSE 5 
-       END`
+    `SELECT m.*
+       FROM meals m
+      WHERE m.user_id = ? AND m.date = ?
+      ORDER BY
+        CASE m.meal_type
+          WHEN 'breakfast' THEN 1
+          WHEN 'lunch' THEN 2
+          WHEN 'dinner' THEN 3
+          WHEN 'snack' THEN 4
+          ELSE 5
+        END,
+        m.created_at ASC`
   ).bind(user.id, date).all();
-  
-  // Get foods for each meal
+
+  // Fetch child foods per meal for display (still needed for the meal
+  // card's ingredient list).
   const mealsWithFoods = await Promise.all((meals.results || []).map(async (meal) => {
     const foods = await db.prepare(
       `SELECT mf.*, f.name, f.brand, f.serving_description
-       FROM meal_foods mf
-       JOIN foods f ON mf.food_id = f.id
-       WHERE mf.meal_id = ?`
+         FROM meal_foods mf
+         JOIN foods f ON mf.food_id = f.id
+        WHERE mf.meal_id = ?`
     ).bind(meal.id).all();
-    
-    const totals = (foods.results || []).reduce((acc, f) => ({
-      calories: acc.calories + (f.calories || 0),
-      protein_g: acc.protein_g + (f.protein_g || 0),
-      carbs_g: acc.carbs_g + (f.carbs_g || 0),
-      fat_g: acc.fat_g + (f.fat_g || 0)
-    }), { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 });
-    
+
     return {
       ...meal,
       foods: foods.results || [],
-      totals
+      totals: normalizeMacros({
+        calories: meal.calories,
+        protein_g: meal.protein_g,
+        carbs_g: meal.carbs_g,
+        fat_g: meal.fat_g,
+        fiber_g: meal.fiber_g
+      })
     };
   }));
-  
-  // Calculate daily totals
-  const dailyTotals = mealsWithFoods.reduce((acc, meal) => ({
-    calories: acc.calories + meal.totals.calories,
-    protein_g: acc.protein_g + meal.totals.protein_g,
-    carbs_g: acc.carbs_g + meal.totals.carbs_g,
-    fat_g: acc.fat_g + meal.totals.fat_g
-  }), { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 });
-  
+
+  // Daily totals roll up from the cached per-meal totals.
+  const dailyTotals = sumMacros(mealsWithFoods.map((m) => m.totals));
+
   return c.json({
     date,
     meals: mealsWithFoods,
-    daily_totals: {
-      calories: Math.round(dailyTotals.calories),
-      protein_g: Math.round(dailyTotals.protein_g * 10) / 10,
-      carbs_g: Math.round(dailyTotals.carbs_g * 10) / 10,
-      fat_g: Math.round(dailyTotals.fat_g * 10) / 10
-    }
+    daily_totals: dailyTotals
   });
 });
 
 // Delete a meal
+//
+// Reads the cached macro totals from the meals row (migration 0028),
+// subtracts them from nutrition_log (clamping at 0), then deletes the
+// meal — cascade deletes its meal_foods children. Covers all meal types
+// uniformly: meal-logger, quick-add, saved-meal log, custom_macros.
 nutrition.delete('/meals/:id', async (c) => {
   const user = requireAuth(c);
   const mealId = c.req.param('id');
   const db = c.env.DB;
-  
-  // Verify ownership and get meal details for updating daily log
+
   const meal = await db.prepare(
-    `SELECT m.*, SUM(mf.protein_g) as total_protein
-     FROM meals m
-     LEFT JOIN meal_foods mf ON m.id = mf.meal_id
-     WHERE m.id = ? AND m.user_id = ?
-     GROUP BY m.id`
+    `SELECT id, user_id, date, calories, protein_g, carbs_g, fat_g, fiber_g
+       FROM meals
+      WHERE id = ? AND user_id = ?`
   ).bind(mealId, user.id).first();
-  
+
   if (!meal) {
     return c.json({ error: 'Meal not found' }, 404);
   }
-  
-  // Delete meal (cascade deletes meal_foods)
-  await db.prepare('DELETE FROM meals WHERE id = ?').bind(mealId).run();
-  
-  // Update daily nutrition log
-  if (meal.total_protein) {
-    await db.prepare(
-      `UPDATE nutrition_log 
-       SET protein_grams = MAX(0, protein_grams - ?),
-           updated_at = CURRENT_TIMESTAMP
-       WHERE user_id = ? AND date = ?`
-    ).bind(Math.round(meal.total_protein), user.id, meal.date).run();
-  }
-  
+
+  // Subtract the meal's macros from the daily log FIRST. If the delete
+  // below somehow fails, the log will still reflect reality on retry
+  // (subtract is idempotent when clamped).
+  await subtractFromNutritionLog(db, user.id, meal.date, {
+    calories: meal.calories,
+    protein_g: meal.protein_g,
+    carbs_g: meal.carbs_g,
+    fat_g: meal.fat_g,
+    fiber_g: meal.fiber_g
+  });
+
+  await db.prepare('DELETE FROM meals WHERE id = ? AND user_id = ?')
+    .bind(mealId, user.id).run();
+
   return c.json({ message: 'Meal deleted' });
 });
 
@@ -1833,53 +1827,57 @@ nutrition.post('/foods/:id/favorite', async (c) => {
   return c.json({ is_favorite: existing ? !existing.is_favorite : true });
 });
 
-// Quick add food (simplified logging)
+// Quick add food (simplified single-food logging — used by the barcode
+// scanner's "Log It" button and frequent-foods/favorites quick actions).
+//
+// Finds-or-creates an UNNAMED meal row for the (user, date, meal_type)
+// so repeated quick-adds on the same day accumulate into one "meal"
+// card instead of producing N separate rows. The cached macros on that
+// meal row are recomputed after each add.
 nutrition.post('/quick-add', async (c) => {
   const user = requireAuth(c);
   const body = await c.req.json();
   const db = c.env.DB;
-  
+
   const { food_id, quantity, unit, meal_type, date } = body;
-  
+
   if (!food_id) {
     return c.json({ error: 'food_id is required' }, 400);
   }
-  
+
   const mealDate = date || new Date().toISOString().split('T')[0];
   const mealTypeValue = meal_type || 'snack';
-  
-  // Get or create meal for this date/type
+
+  // Get or create a dedicated "quick-add bucket" meal for this slot
+  // (name IS NULL identifies it; saved-meal logs set `name`).
   let meal = await db.prepare(
-    `SELECT * FROM meals 
-     WHERE user_id = ? AND date = ? AND meal_type = ? AND name IS NULL
-     LIMIT 1`
+    `SELECT * FROM meals
+      WHERE user_id = ? AND date = ? AND meal_type = ? AND name IS NULL
+      LIMIT 1`
   ).bind(user.id, mealDate, mealTypeValue).first();
-  
+
   if (!meal) {
     meal = await db.prepare(
-      `INSERT INTO meals (user_id, date, meal_type)
-       VALUES (?, ?, ?)
-       RETURNING *`
+      `INSERT INTO meals (user_id, date, meal_type) VALUES (?, ?, ?) RETURNING *`
     ).bind(user.id, mealDate, mealTypeValue).first();
   }
-  
-  // Get food
+
   const food = await db.prepare('SELECT * FROM foods WHERE id = ?').bind(food_id).first();
   if (!food) {
     return c.json({ error: 'Food not found' }, 404);
   }
-  
+
   const qty = quantity || 1;
   const unitValue = unit || 'serving';
   const macros = calculateMacros(food, qty, unitValue);
-  
-  // Add to meal
+
+  // Insert the meal_foods row.
   await db.prepare(
     `INSERT INTO meal_foods (meal_id, food_id, quantity, unit, calories, protein_g, carbs_g, fat_g)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
   ).bind(meal.id, food_id, qty, unitValue, macros.calories, macros.protein_g, macros.carbs_g, macros.fat_g).run();
-  
-  // Update favorites
+
+  // Track favorite/frequent usage.
   await db.prepare(
     `INSERT INTO user_favorite_foods (user_id, food_id, use_count, last_used)
      VALUES (?, ?, 1, CURRENT_TIMESTAMP)
@@ -1887,22 +1885,23 @@ nutrition.post('/quick-add', async (c) => {
        use_count = use_count + 1,
        last_used = CURRENT_TIMESTAMP`
   ).bind(user.id, food_id).run();
-  
-  // Update daily log
-  await db.prepare(
-    `INSERT INTO nutrition_log (user_id, date, protein_grams, updated_at)
-     VALUES (?, ?, ?, CURRENT_TIMESTAMP)
-     ON CONFLICT(user_id, date) DO UPDATE SET
-       protein_grams = protein_grams + excluded.protein_grams,
-       updated_at = CURRENT_TIMESTAMP`
-  ).bind(user.id, mealDate, Math.round(macros.protein_g)).run();
-  
+
+  // Re-sum the meal's totals from meal_foods and cache on the meals row.
+  // (Because multiple quick-adds accumulate into the same meal, we can't
+  // just add this one delta — we recompute to stay in sync.)
+  await recomputeMealTotals(db, meal.id);
+
+  // Add this add's macros to the daily log. The log is append-only here;
+  // we add the delta we just inserted, not the full recomputed total.
+  await addToNutritionLog(db, user.id, mealDate, macros);
+
   return c.json({
     added: {
+      meal_id: meal.id,
       food_name: food.name,
       quantity: qty,
       unit: unitValue,
-      macros
+      macros: normalizeMacros(macros)
     },
     message: 'Food added'
   });
@@ -2016,6 +2015,12 @@ nutrition.delete('/saved-meals/:id', async (c) => {
 });
 
 // Log a saved meal (add to today's nutrition)
+//
+// Always creates its OWN meals row (no "merge into existing meal" behavior)
+// so deleting that logged instance cleanly removes exactly what was added.
+// Caches the full macro breakdown on the meals row so /activity and
+// DELETE /meals/:id read from a single source. Also copies saved_meal_foods
+// into meal_foods (when present) so the meal card shows its ingredients.
 nutrition.post('/saved-meals/:id/log', async (c) => {
   const user = requireAuth(c);
   const mealId = c.req.param('id');
@@ -2037,7 +2042,6 @@ nutrition.post('/saved-meals/:id/log', async (c) => {
   const { date, meal_type } = body;
   const logDate = date || new Date().toISOString().split('T')[0];
 
-  // Get the saved meal
   const savedMeal = await db.prepare(
     'SELECT * FROM saved_meals WHERE id = ? AND user_id = ?'
   ).bind(mealId, user.id).first();
@@ -2048,21 +2052,32 @@ nutrition.post('/saved-meals/:id/log', async (c) => {
 
   const effectiveMealType = meal_type || savedMeal.meal_type || 'snack';
 
-  // Create or get today's meal entry so the saved meal also appears in the
-  // "Today's meals" list on the Nutrition screen.
-  let meal = await db.prepare(
-    'SELECT * FROM meals WHERE user_id = ? AND date = ? AND meal_type = ?'
-  ).bind(user.id, logDate, effectiveMealType).first();
+  // Normalize saved meal macros (any field may be null). These become both
+  // the cached meal totals AND the nutrition_log delta — single source of
+  // truth, so delete will subtract exactly what was added.
+  const macros = normalizeMacros({
+    calories:  savedMeal.calories,
+    protein_g: savedMeal.protein_g,
+    carbs_g:   savedMeal.carbs_g,
+    fat_g:     savedMeal.fat_g,
+    fiber_g:   savedMeal.fiber_g
+  });
 
-  if (!meal) {
-    meal = await db.prepare(
-      `INSERT INTO meals (user_id, date, meal_type, name) VALUES (?, ?, ?, ?) RETURNING *`
-    ).bind(user.id, logDate, effectiveMealType, savedMeal.name).first();
-  }
+  // Always create a fresh meal row for this log so deletion is surgical.
+  const meal = await db.prepare(
+    `INSERT INTO meals
+       (user_id, date, meal_type, name, calories, protein_g, carbs_g, fat_g, fiber_g)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     RETURNING *`
+  ).bind(
+    user.id, logDate, effectiveMealType, savedMeal.name,
+    macros.calories, macros.protein_g, macros.carbs_g, macros.fat_g, macros.fiber_g
+  ).first();
 
   // Copy saved-meal foods (if any) into meal_foods so the meal card shows
   // its ingredients. Saved meals created from recipe URLs or pure macros
-  // will have no foods — that's fine, we still update the daily log below.
+  // will have no foods — in that case the cached macros on the meal row
+  // are the sole source, which is exactly what /activity + DELETE read.
   const savedFoods = await db.prepare(
     'SELECT * FROM saved_meal_foods WHERE saved_meal_id = ?'
   ).bind(mealId).all();
@@ -2084,29 +2099,8 @@ nutrition.post('/saved-meals/:id/log', async (c) => {
     ).run();
   }
 
-  // Normalize macros from the saved meal (any field may be null).
-  const calories = Math.max(0, Math.round(Number(savedMeal.calories) || 0));
-  const protein = Math.round((Number(savedMeal.protein_g) || 0) * 10) / 10;
-  const carbs = Math.round((Number(savedMeal.carbs_g) || 0) * 10) / 10;
-  const fat = Math.round((Number(savedMeal.fat_g) || 0) * 10) / 10;
-  const fiber = Math.round((Number(savedMeal.fiber_g) || 0) * 10) / 10;
-
-  // Update daily nutrition log with the FULL macro breakdown so the rings
-  // and AI nutrition coach see the logged saved meal correctly. Prior to
-  // this fix only protein was added, leaving calories/carbs/fat silently
-  // missing from the daily totals.
-  await db.prepare(
-    `INSERT INTO nutrition_log
-       (user_id, date, calories, protein_grams, carbs_grams, fat_grams, fiber_grams, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-     ON CONFLICT(user_id, date) DO UPDATE SET
-       calories = COALESCE(calories, 0) + excluded.calories,
-       protein_grams = COALESCE(protein_grams, 0) + excluded.protein_grams,
-       carbs_grams = COALESCE(carbs_grams, 0) + excluded.carbs_grams,
-       fat_grams = COALESCE(fat_grams, 0) + excluded.fat_grams,
-       fiber_grams = COALESCE(fiber_grams, 0) + excluded.fiber_grams,
-       updated_at = CURRENT_TIMESTAMP`
-  ).bind(user.id, logDate, calories, protein, carbs, fat, fiber).run();
+  // Add to daily nutrition_log.
+  await addToNutritionLog(db, user.id, logDate, macros);
 
   // Update saved meal usage
   await db.prepare(
@@ -2115,14 +2109,11 @@ nutrition.post('/saved-meals/:id/log', async (c) => {
 
   return c.json({
     logged: {
+      meal_id: meal.id,
       meal_name: savedMeal.name,
       meal_type: effectiveMealType,
       date: logDate,
-      calories,
-      protein_g: protein,
-      carbs_g: carbs,
-      fat_g: fat,
-      fiber_g: fiber
+      ...macros
     },
     message: 'Meal logged'
   });

--- a/src/utils/nutrition-ledger.js
+++ b/src/utils/nutrition-ledger.js
@@ -1,0 +1,191 @@
+/**
+ * Nutrition ledger — single source of truth for maintaining consistency
+ * between meal / entry rows and the daily `nutrition_log` aggregate that
+ * feeds the progress rings on the Nutrition screen.
+ *
+ * Architectural rules this module enforces:
+ *
+ *   1. Every write that creates or increases a meal / entry must call
+ *      `addToNutritionLog` with the same macros that were stored on the
+ *      child row(s).
+ *   2. Every delete / decrement must call `subtractFromNutritionLog`
+ *      with the exact same macros, before the row is removed.
+ *   3. `nutrition_log` columns are clamped at >= 0 by the subtract path
+ *      (D1 has no native CHECK, so we do MAX(0, x - delta) in SQL).
+ *   4. The `meals.calories / protein_g / carbs_g / fat_g / fiber_g`
+ *      columns (added in migration 0028) are the canonical per-meal
+ *      totals. Read them; don't re-SUM meal_foods on every read.
+ *
+ * Callers never need to touch `nutrition_log` directly — always go
+ * through these helpers so nothing drifts.
+ */
+
+/**
+ * Normalize an arbitrary macros-shaped object to the 5-field canonical
+ * shape with numeric zeros where fields are missing/NaN. Rounds to 1
+ * decimal for macros and whole numbers for calories so the display in
+ * the rings and activity feed never shows 0.7293 g.
+ */
+export function normalizeMacros(m = {}) {
+  const num = (v) => {
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  };
+  return {
+    calories: Math.round(num(m.calories)),
+    protein_g: Math.round(num(m.protein_g ?? m.protein_grams ?? m.protein) * 10) / 10,
+    carbs_g: Math.round(num(m.carbs_g ?? m.carbs_grams ?? m.carbs) * 10) / 10,
+    fat_g: Math.round(num(m.fat_g ?? m.fat_grams ?? m.fat) * 10) / 10,
+    fiber_g: Math.round(num(m.fiber_g ?? m.fiber_grams ?? m.fiber) * 10) / 10
+  };
+}
+
+/**
+ * Sum a list of meal_foods (or any array of per-item macro objects) into
+ * a single totals object.
+ */
+export function sumMacros(items = []) {
+  const totals = { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0 };
+  for (const it of items) {
+    if (!it) continue;
+    totals.calories += Number(it.calories) || 0;
+    totals.protein_g += Number(it.protein_g) || 0;
+    totals.carbs_g += Number(it.carbs_g) || 0;
+    totals.fat_g += Number(it.fat_g) || 0;
+    totals.fiber_g += Number(it.fiber_g) || 0;
+  }
+  return normalizeMacros(totals);
+}
+
+/**
+ * Overwrite the cached totals on a `meals` row. Pass any partial macros
+ * object — missing fields are treated as 0.
+ */
+export async function setMealTotals(db, mealId, macros) {
+  const m = normalizeMacros(macros);
+  await db.prepare(
+    `UPDATE meals
+        SET calories = ?, protein_g = ?, carbs_g = ?, fat_g = ?, fiber_g = ?
+      WHERE id = ?`
+  ).bind(m.calories, m.protein_g, m.carbs_g, m.fat_g, m.fiber_g, mealId).run();
+  return m;
+}
+
+/**
+ * Recompute a meal's cached totals by summing its `meal_foods` rows.
+ * Used after adding/removing ingredients when we don't have the delta
+ * already computed in JS.
+ */
+export async function recomputeMealTotals(db, mealId) {
+  const result = await db.prepare(
+    `SELECT COALESCE(SUM(calories),  0) AS calories,
+            COALESCE(SUM(protein_g), 0) AS protein_g,
+            COALESCE(SUM(carbs_g),   0) AS carbs_g,
+            COALESCE(SUM(fat_g),     0) AS fat_g
+       FROM meal_foods
+      WHERE meal_id = ?`
+  ).bind(mealId).first();
+  // fiber isn't tracked on meal_foods by design; preserve whatever is
+  // already on the row so macro-only / recipe-URL meals don't lose fiber.
+  const existing = await db.prepare(
+    `SELECT fiber_g FROM meals WHERE id = ?`
+  ).bind(mealId).first();
+  const macros = {
+    ...result,
+    fiber_g: existing?.fiber_g || 0
+  };
+  return setMealTotals(db, mealId, macros);
+}
+
+/**
+ * Add the given macros to `nutrition_log` for a user/date, creating the
+ * row if it doesn't exist. Caller is expected to pass normalized macros
+ * (use `normalizeMacros()` if in doubt).
+ */
+export async function addToNutritionLog(db, userId, date, macros) {
+  const m = normalizeMacros(macros);
+  if (!m.calories && !m.protein_g && !m.carbs_g && !m.fat_g && !m.fiber_g) {
+    return m; // nothing to do; skip a pointless UPDATE
+  }
+  await db.prepare(
+    `INSERT INTO nutrition_log
+       (user_id, date, calories, protein_grams, carbs_grams, fat_grams, fiber_grams, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+     ON CONFLICT(user_id, date) DO UPDATE SET
+       calories      = COALESCE(calories,      0) + excluded.calories,
+       protein_grams = COALESCE(protein_grams, 0) + excluded.protein_grams,
+       carbs_grams   = COALESCE(carbs_grams,   0) + excluded.carbs_grams,
+       fat_grams     = COALESCE(fat_grams,     0) + excluded.fat_grams,
+       fiber_grams   = COALESCE(fiber_grams,   0) + excluded.fiber_grams,
+       updated_at    = CURRENT_TIMESTAMP`
+  ).bind(userId, date, m.calories, m.protein_g, m.carbs_g, m.fat_g, m.fiber_g).run();
+  return m;
+}
+
+/**
+ * Subtract macros from `nutrition_log` for a user/date, clamping at 0.
+ * Safe to call even if the row doesn't exist (no-op).
+ */
+export async function subtractFromNutritionLog(db, userId, date, macros) {
+  const m = normalizeMacros(macros);
+  if (!m.calories && !m.protein_g && !m.carbs_g && !m.fat_g && !m.fiber_g) {
+    return m;
+  }
+  await db.prepare(
+    `UPDATE nutrition_log
+        SET calories      = MAX(0, COALESCE(calories,      0) - ?),
+            protein_grams = MAX(0, COALESCE(protein_grams, 0) - ?),
+            carbs_grams   = MAX(0, COALESCE(carbs_grams,   0) - ?),
+            fat_grams     = MAX(0, COALESCE(fat_grams,     0) - ?),
+            fiber_grams   = MAX(0, COALESCE(fiber_grams,   0) - ?),
+            updated_at    = CURRENT_TIMESTAMP
+      WHERE user_id = ? AND date = ?`
+  ).bind(m.calories, m.protein_g, m.carbs_g, m.fat_g, m.fiber_g, userId, date).run();
+  return m;
+}
+
+/**
+ * Map a nutrition_entries `entry_type` to the scalar nutrition_log column
+ * the `amount` contributes to. Useful for single-column adjust/delete.
+ */
+export function entryColumnFor(entryType) {
+  switch (entryType) {
+    case 'protein':  return 'protein_grams';
+    case 'water':    return 'water_ml';
+    case 'creatine': return 'creatine_grams';
+    default:         return null;
+  }
+}
+
+/**
+ * Add a scalar entry (protein/water/creatine) to nutrition_log.
+ */
+export async function addEntryToLog(db, userId, date, entryType, amount) {
+  const column = entryColumnFor(entryType);
+  if (!column) return;
+  const n = Math.max(0, Number(amount) || 0);
+  if (!n) return;
+  await db.prepare(
+    `INSERT INTO nutrition_log (user_id, date, ${column}, updated_at)
+     VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+     ON CONFLICT(user_id, date) DO UPDATE SET
+       ${column} = COALESCE(${column}, 0) + excluded.${column},
+       updated_at = CURRENT_TIMESTAMP`
+  ).bind(userId, date, n).run();
+}
+
+/**
+ * Subtract a scalar entry from nutrition_log, clamping at 0.
+ */
+export async function subtractEntryFromLog(db, userId, date, entryType, amount) {
+  const column = entryColumnFor(entryType);
+  if (!column) return;
+  const n = Math.max(0, Number(amount) || 0);
+  if (!n) return;
+  await db.prepare(
+    `UPDATE nutrition_log
+        SET ${column} = MAX(0, COALESCE(${column}, 0) - ?),
+            updated_at = CURRENT_TIMESTAMP
+      WHERE user_id = ? AND date = ?`
+  ).bind(n, userId, date).run();
+}

--- a/tests/unit/nutrition-ledger.test.js
+++ b/tests/unit/nutrition-ledger.test.js
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  normalizeMacros,
+  sumMacros,
+  setMealTotals,
+  recomputeMealTotals,
+  addToNutritionLog,
+  subtractFromNutritionLog,
+  addEntryToLog,
+  subtractEntryFromLog,
+  entryColumnFor
+} from '../../src/utils/nutrition-ledger.js';
+
+/**
+ * Tiny D1 mock that records every prepared SQL + bind invocation so tests
+ * can assert both the query shape and the values bound. `first()` /
+ * `all()` / `run()` default to harmless stubs; tests override as needed.
+ */
+function mockDb(resultMap = {}) {
+  const calls = [];
+  const db = {
+    calls,
+    prepare(sql) {
+      const call = { sql, params: null, kind: null };
+      calls.push(call);
+      return {
+        bind(...params) {
+          call.params = params;
+          return {
+            first: async () => {
+              call.kind = 'first';
+              for (const [pattern, value] of Object.entries(resultMap)) {
+                if (sql.includes(pattern)) return value;
+              }
+              return null;
+            },
+            all: async () => {
+              call.kind = 'all';
+              return { results: [] };
+            },
+            run: async () => {
+              call.kind = 'run';
+              return { success: true };
+            }
+          };
+        }
+      };
+    }
+  };
+  return db;
+}
+
+describe('normalizeMacros', () => {
+  it('returns a 5-field canonical shape with numeric zeros for missing fields', () => {
+    expect(normalizeMacros({})).toEqual({
+      calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0
+    });
+  });
+
+  it('rounds calories to integers and macros to 1 decimal', () => {
+    const m = normalizeMacros({
+      calories: 423.7293,
+      protein_g: 35.12345,
+      carbs_g: 40.06,
+      fat_g: 12.349,
+      fiber_g: 5.55
+    });
+    expect(m.calories).toBe(424);
+    expect(m.protein_g).toBe(35.1);
+    expect(m.carbs_g).toBe(40.1);
+    expect(m.fat_g).toBe(12.3);
+    expect(m.fiber_g).toBe(5.6);
+  });
+
+  it('accepts legacy alias keys (protein_grams, protein)', () => {
+    expect(normalizeMacros({ protein_grams: 20 }).protein_g).toBe(20);
+    expect(normalizeMacros({ protein: 30 }).protein_g).toBe(30);
+  });
+
+  it('clamps negatives and non-finite numbers to zero', () => {
+    const m = normalizeMacros({
+      calories: -100,
+      protein_g: NaN,
+      carbs_g: null,
+      fat_g: undefined,
+      fiber_g: 'bogus'
+    });
+    expect(m).toEqual({ calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0 });
+  });
+
+  it('coerces numeric strings', () => {
+    expect(normalizeMacros({ calories: '500', protein_g: '30' })).toMatchObject({
+      calories: 500,
+      protein_g: 30
+    });
+  });
+});
+
+describe('sumMacros', () => {
+  it('sums a list of meal_foods-shaped rows to normalized totals', () => {
+    const totals = sumMacros([
+      { calories: 200, protein_g: 20, carbs_g: 10, fat_g: 5, fiber_g: 2 },
+      { calories: 150, protein_g: 10, carbs_g: 20, fat_g: 3, fiber_g: 1 },
+      { calories: 50,  protein_g: 0,  carbs_g: 12, fat_g: 2 }
+    ]);
+    expect(totals).toEqual({
+      calories: 400,
+      protein_g: 30,
+      carbs_g: 42,
+      fat_g: 10,
+      fiber_g: 3
+    });
+  });
+
+  it('tolerates empty / null / undefined items', () => {
+    expect(sumMacros([null, undefined, {}])).toEqual({
+      calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0
+    });
+    expect(sumMacros()).toEqual({
+      calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0
+    });
+  });
+});
+
+describe('setMealTotals', () => {
+  it('issues an UPDATE meals SET … with normalized macros', async () => {
+    const db = mockDb();
+    await setMealTotals(db, 42, { calories: 500.7, protein_g: 30.12, carbs_g: 50, fat_g: 15 });
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0].sql).toMatch(/UPDATE meals/);
+    expect(db.calls[0].sql).toMatch(/calories = \?/);
+    expect(db.calls[0].params).toEqual([501, 30.1, 50, 15, 0, 42]);
+  });
+});
+
+describe('recomputeMealTotals', () => {
+  it('SUMs meal_foods and preserves existing fiber_g on the meal row', async () => {
+    const db = mockDb({
+      'FROM meal_foods': { calories: 300, protein_g: 25, carbs_g: 40, fat_g: 10 },
+      'FROM meals': { fiber_g: 7 }
+    });
+    await recomputeMealTotals(db, 7);
+    // Three prepare() calls: SUM meal_foods, SELECT meals.fiber_g, UPDATE meals
+    expect(db.calls.length).toBe(3);
+    const update = db.calls[2];
+    expect(update.sql).toMatch(/UPDATE meals/);
+    expect(update.params[0]).toBe(300); // calories
+    expect(update.params[4]).toBe(7);   // preserved fiber_g
+    expect(update.params[5]).toBe(7);   // meal id
+  });
+});
+
+describe('addToNutritionLog', () => {
+  it('does an upsert INSERT ... ON CONFLICT adding macros to the day', async () => {
+    const db = mockDb();
+    await addToNutritionLog(db, 1, '2026-04-21', {
+      calories: 500, protein_g: 30, carbs_g: 50, fat_g: 15, fiber_g: 4
+    });
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0].sql).toMatch(/INSERT INTO nutrition_log/);
+    expect(db.calls[0].sql).toMatch(/ON CONFLICT/);
+    expect(db.calls[0].sql).toMatch(/calories\s+=\s+COALESCE\(calories,\s+0\)\s+\+\s+excluded\.calories/);
+    expect(db.calls[0].params).toEqual([1, '2026-04-21', 500, 30, 50, 15, 4]);
+  });
+
+  it('skips the DB round-trip when every macro is zero', async () => {
+    const db = mockDb();
+    await addToNutritionLog(db, 1, '2026-04-21', {});
+    expect(db.calls).toHaveLength(0);
+  });
+});
+
+describe('subtractFromNutritionLog', () => {
+  it('clamps each column to >= 0 via MAX(0, col - ?)', async () => {
+    const db = mockDb();
+    await subtractFromNutritionLog(db, 1, '2026-04-21', {
+      calories: 200, protein_g: 10, carbs_g: 20, fat_g: 5, fiber_g: 1
+    });
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0].sql).toMatch(/UPDATE nutrition_log/);
+    expect(db.calls[0].sql).toMatch(/MAX\(0,\s+COALESCE\(calories,\s+0\)\s+-\s+\?\)/);
+    expect(db.calls[0].params).toEqual([200, 10, 20, 5, 1, 1, '2026-04-21']);
+  });
+
+  it('no-ops when all macros are zero', async () => {
+    const db = mockDb();
+    await subtractFromNutritionLog(db, 1, '2026-04-21', { calories: 0 });
+    expect(db.calls).toHaveLength(0);
+  });
+});
+
+describe('entryColumnFor', () => {
+  it('maps each known entry type to its nutrition_log column', () => {
+    expect(entryColumnFor('protein')).toBe('protein_grams');
+    expect(entryColumnFor('water')).toBe('water_ml');
+    expect(entryColumnFor('creatine')).toBe('creatine_grams');
+  });
+
+  it('returns null for unknown entry types', () => {
+    expect(entryColumnFor('fiber')).toBeNull();
+    expect(entryColumnFor(undefined)).toBeNull();
+  });
+});
+
+describe('addEntryToLog / subtractEntryFromLog', () => {
+  it('addEntryToLog UPSERTs the column matching the entry_type', async () => {
+    const db = mockDb();
+    await addEntryToLog(db, 1, '2026-04-21', 'water', 500);
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0].sql).toMatch(/INSERT INTO nutrition_log \(user_id, date, water_ml, updated_at\)/);
+    expect(db.calls[0].sql).toMatch(/water_ml = COALESCE\(water_ml, 0\) \+ excluded\.water_ml/);
+    expect(db.calls[0].params).toEqual([1, '2026-04-21', 500]);
+  });
+
+  it('subtractEntryFromLog updates only the matching column with MAX(0, ...)', async () => {
+    const db = mockDb();
+    await subtractEntryFromLog(db, 1, '2026-04-21', 'protein', 30);
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0].sql).toMatch(/UPDATE nutrition_log/);
+    expect(db.calls[0].sql).toMatch(/protein_grams = MAX\(0, COALESCE\(protein_grams, 0\) - \?\)/);
+    expect(db.calls[0].params).toEqual([30, 1, '2026-04-21']);
+  });
+
+  it('skips unknown entry types with no DB call', async () => {
+    const db = mockDb();
+    await addEntryToLog(db, 1, '2026-04-21', 'bogus', 10);
+    await subtractEntryFromLog(db, 1, '2026-04-21', 'bogus', 10);
+    expect(db.calls).toHaveLength(0);
+  });
+
+  it('skips zero / negative amounts', async () => {
+    const db = mockDb();
+    await addEntryToLog(db, 1, '2026-04-21', 'protein', 0);
+    await addEntryToLog(db, 1, '2026-04-21', 'protein', -5);
+    expect(db.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Rebuilds the nutrition subsystem so every write, delete, and read path agrees on a single source of truth, and fixes the standalone barcode-scan UX. Addresses three user-reported bugs:

1. **Saved-meal logs show no macros in the 14-day Activity modal.**
2. **Deleting a meal doesn't adjust the progress rings** (they drift permanently upward).
3. **Scanning a barcode from the Nutrition screen shows "Added X" but doesn't log anything** and offers no save-for-later option.

## Root cause

Macros lived **only** on `meal_foods` child rows. Saved-meal logs frequently produce a `meals` row with no `meal_foods` children (recipe-URL and macro-only templates), so `SUM(meal_foods.*)` returned 0 everywhere that read them. Writes to `nutrition_log`, meanwhile, already added the saved meal's macros at log time — so the log drifted upward on every delete. And every delete handler only subtracted `protein_grams` anyway. The bugs compounded each other.

## Architectural change: cached macros on the `meals` row

Migration **0028** adds `calories / protein_g / carbs_g / fat_g / fiber_g` to `meals` and backfills from `meal_foods`. Every meal-creating endpoint now stores the totals on the meal row itself — that row is the single source of truth for everything downstream.

New helper module **`src/utils/nutrition-ledger.js`** centralizes the accounting rules:

| Helper | Purpose |
|---|---|
| `normalizeMacros(m)` | Canonical 5-field shape, rounded |
| `sumMacros([...])` | Roll up an array of per-row macros |
| `setMealTotals(db, id, m)` | Cache on the `meals` row |
| `recomputeMealTotals(db, id)` | Re-SUM from `meal_foods` (preserves fiber) |
| `addToNutritionLog(db, u, d, m)` | Upsert + add the full breakdown |
| `subtractFromNutritionLog(...)` | `MAX(0, col - ?)` clamped subtract |
| `addEntryToLog / subtractEntryFromLog` | Scalar protein/water/creatine |
| `entryColumnFor(type)` | `'protein' → 'protein_grams'`, etc. |

## Endpoints refactored

| Endpoint | Change |
|---|---|
| `POST /nutrition/meals` | Now honors `custom_macros` (Quick Macro Entry no longer silently creates an empty meal), caches totals on the meal row, adds to log |
| `POST /nutrition/quick-add` | Writes **full** macros to `nutrition_log` (was protein-only); recomputes cached totals after each add |
| `POST /nutrition/saved-meals/:id/log` | Creates its **own** `meals` row (no merge-into-existing) so deletion is surgical; caches macros; full log update |
| `POST /nutrition/entries` | Uses `addEntryToLog` helper |
| `PUT /nutrition/entries/:id` | Rebalances **both** days when `logged_at` date moves (old day used to stay inflated) |
| `DELETE /nutrition/meals/:id` | Reads cached macros, subtracts calories + protein + carbs + fat + fiber (was protein-only) |
| `DELETE /nutrition/entries/:id` | Uses `subtractEntryFromLog` |
| `GET /nutrition/meals` | Reads cached totals (saved-meal logs with no `meal_foods` now show their macros) |
| `GET /nutrition/activity` | Reads cached totals directly — O(1) per meal, no N+1 SUM |

## Standalone barcode logging UX

Previously "Scan Barcode" on the Nutrition screen opened the scanner with no parent meal-logger modal. After scanning, "Add to Meal" pushed the food into an in-memory buffer that no modal was reading. The food was silently dropped while showing a misleading "Added X" toast.

The scan-result card is now **context-aware**:

- **Inside the meal-logger modal:** unchanged "Add to Meal" behavior.
- **Standalone (from the Nutrition screen):** quantity input + meal-type selector (auto-detected by time of day) + three actions:
  - **Log It** — `POST /nutrition/quick-add` immediately, refreshes rings
  - **Save** — `POST /nutrition/foods/:id/favorite`, so the food lives in the Favorites list for later
  - **Build a full meal with this** — promotes the scan into a full meal-logger modal with the food pre-loaded, so the user can keep adding items

## Remote migration

Applied to remote D1 **before** this commit was pushed, so the deployed worker meets the new schema on arrival:
```
$ npx wrangler d1 migrations apply fitness-coach-db --remote
✅ 0028_meals_macros_cache.sql
```
Backfill populated 1 / 2 existing meals from `meal_foods`. The un-backfilled one is precisely the saved-meal log whose macros were lost under the old architecture — it retains 0 until edited, same behavior as before the fix for that single historical row.

## Tests

**19 new** unit tests in `tests/unit/nutrition-ledger.test.js` cover:
- normalization shape + rounding
- missing / NaN / negative / string-numeric macros
- `sumMacros` over heterogeneous rows
- `setMealTotals` / `recomputeMealTotals` SQL shape and bound params
- `addToNutritionLog` UPSERT with COALESCE
- `subtractFromNutritionLog` with `MAX(0, col - ?)` clamping
- `entryColumnFor` mapping
- `addEntryToLog` / `subtractEntryFromLog` for all three entry types
- no-op skipping for zero / unknown inputs

**Full suite: 130 / 130 pass.** `wrangler deploy --dry-run` clean (383 KiB / 80 KiB gzipped).

## Files

- `migrations/0028_meals_macros_cache.sql` — new
- `src/utils/nutrition-ledger.js` — new helper module
- `tests/unit/nutrition-ledger.test.js` — new (19 tests)
- `src/routes/nutrition.js` — refactored 10 endpoints (+212 / -277 lines)
- `frontend/src/features/nutrition/meal-logger.js` — context-aware scan UX (+110 / -24 lines)