### PR TITLE
Reconcile nutrition_log (heal historical drift)

### DIFF
--- a/frontend/src/screens/nutrition.js
+++ b/frontend/src/screens/nutrition.js
@@ -341,6 +341,33 @@ async function logAllQuick() {
   }
 }
 
+/**
+ * Rebuild the daily nutrition_log totals from the ground-truth rows
+ * (meals + nutrition_entries) for the last 30 days, then refresh the
+ * screen. Used when the progress rings have drifted from the actual
+ * logged data (e.g. accumulated historical drift from older code paths).
+ */
+async function reconcileLog(btn) {
+  const original = btn ? btn.innerHTML : '';
+  if (btn) {
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Recalculating…';
+  }
+  try {
+    const res = await api.post('/nutrition/reconcile');
+    const days = res?.count || Object.keys(res?.reconciled || {}).length || 0;
+    toast.success(`Totals recalculated for ${days} day${days === 1 ? '' : 's'}`);
+    loadNutrition();
+  } catch (err) {
+    toast.error(`Couldn't recalculate: ${err.message}`);
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.innerHTML = original;
+    }
+  }
+}
+
 function attachNutritionHandlers(container) {
   delegate(container, 'click', (event) => {
     const target = event.target.closest('[data-action]');
@@ -365,6 +392,9 @@ function attachNutritionHandlers(container) {
         break;
       case 'view-entries':
         delegateToLegacy('loadNutritionEntries');
+        break;
+      case 'reconcile-log':
+        reconcileLog(target);
         break;
       case 'create-saved':
         delegateToLegacy('showCreateSavedMeal');
@@ -461,9 +491,15 @@ export async function loadNutrition() {
         <div class="card">
           <div class="card-header">
             <h2 class="card-title"><i class="fas fa-calendar-alt"></i> Last 14 Days</h2>
-            <button class="btn btn-outline btn-sm" data-action="view-entries">
-              <i class="fas fa-list"></i> View all entries
-            </button>
+            <div class="cluster" style="gap: var(--space-2);">
+              <button class="btn btn-ghost btn-sm" data-action="reconcile-log"
+                      title="If the progress rings ever disagree with your logged entries, this rebuilds the daily totals from the source.">
+                <i class="fas fa-sync-alt"></i> Recalculate
+              </button>
+              <button class="btn btn-outline btn-sm" data-action="view-entries">
+                <i class="fas fa-list"></i> View all entries
+              </button>
+            </div>
           </div>
           ${renderRecentDays(dailyData, summary)}
         </div>

--- a/src/routes/nutrition.js
+++ b/src/routes/nutrition.js
@@ -9,7 +9,9 @@ import {
   subtractFromNutritionLog,
   addEntryToLog,
   subtractEntryFromLog,
-  entryColumnFor
+  entryColumnFor,
+  reconcileNutritionLog,
+  reconcileNutritionLogRange
 } from '../utils/nutrition-ledger';
 
 const nutrition = new Hono();
@@ -590,6 +592,97 @@ nutrition.delete('/daily/:date', async (c) => {
   ).bind(user.id, date).run();
 
   return c.json({ message: 'Nutrition log deleted' });
+});
+
+// ============================================================================
+// Daily nutrition log: direct edit / delete by date.
+//
+// The "Edit daily log" modal in the UI posts to these paths. Previously
+// there were no backend handlers at all — every request silently 404'd.
+// These edits bypass the entries/meals ground truth, so a subsequent
+// /reconcile will overwrite them with the recomputed sum. That's
+// intentional: this is an escape hatch for ad-hoc fixes.
+// ============================================================================
+
+// Direct edit of today's protein/water/creatine totals.
+nutrition.patch('/logs/:date', async (c) => {
+  const user = requireAuth(c);
+  const date = c.req.param('date');
+  const body = await c.req.json().catch(() => ({}));
+  const db = c.env.DB;
+
+  const protein  = Number(body.protein_grams)  || 0;
+  const water    = Number(body.water_ml)       || 0;
+  const creatine = Number(body.creatine_grams) || 0;
+
+  await db.prepare(
+    `INSERT INTO nutrition_log (user_id, date, protein_grams, water_ml, creatine_grams, updated_at)
+     VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+     ON CONFLICT(user_id, date) DO UPDATE SET
+       protein_grams  = excluded.protein_grams,
+       water_ml       = excluded.water_ml,
+       creatine_grams = excluded.creatine_grams,
+       updated_at     = CURRENT_TIMESTAMP`
+  ).bind(user.id, date, protein, water, creatine).run();
+
+  const log = await db.prepare(
+    'SELECT * FROM nutrition_log WHERE user_id = ? AND date = ?'
+  ).bind(user.id, date).first();
+
+  return c.json({ log, message: 'Nutrition log updated' });
+});
+
+// Direct delete of today's log row (rings reset to zero for that day).
+nutrition.delete('/logs/:date', async (c) => {
+  const user = requireAuth(c);
+  const date = c.req.param('date');
+  const db = c.env.DB;
+
+  await db.prepare(
+    'DELETE FROM nutrition_log WHERE user_id = ? AND date = ?'
+  ).bind(user.id, date).run();
+
+  return c.json({ message: 'Nutrition log deleted' });
+});
+
+// ============================================================================
+// Reconcile nutrition_log from ground truth.
+//
+// Rebuilds the daily aggregate row(s) from the actual `meals` + `nutrition_entries`
+// rows for the specified date range. Use this to heal historical drift
+// that accumulated under older write/delete code paths, or after any
+// batch operation where consistency is uncertain.
+//
+// Accepted query params:
+//   ?date=YYYY-MM-DD                  — reconcile a single date
+//   ?start_date=...&end_date=...      — reconcile a range (inclusive)
+//   (none)                            — reconcile the last 30 days
+//
+// Returns { reconciled: { "YYYY-MM-DD": { calories, protein_grams, ... } } }
+// ============================================================================
+nutrition.post('/reconcile', async (c) => {
+  const user = requireAuth(c);
+  const db = c.env.DB;
+
+  const singleDate = c.req.query('date');
+  if (singleDate) {
+    const totals = await reconcileNutritionLog(db, user.id, singleDate);
+    return c.json({ reconciled: { [singleDate]: totals } });
+  }
+
+  const today = new Date().toISOString().split('T')[0];
+  const defaultStart = new Date(Date.now() - 29 * 24 * 60 * 60 * 1000)
+    .toISOString().split('T')[0];
+  const startDate = c.req.query('start_date') || defaultStart;
+  const endDate   = c.req.query('end_date')   || today;
+
+  const reconciled = await reconcileNutritionLogRange(db, user.id, startDate, endDate);
+  return c.json({
+    start_date: startDate,
+    end_date: endDate,
+    reconciled,
+    count: Object.keys(reconciled).length
+  });
 });
 
 // ========== INDIVIDUAL NUTRITION ENTRIES (Timestamped) ==========

--- a/src/utils/nutrition-ledger.js
+++ b/src/utils/nutrition-ledger.js
@@ -189,3 +189,121 @@ export async function subtractEntryFromLog(db, userId, date, entryType, amount) 
       WHERE user_id = ? AND date = ?`
   ).bind(n, userId, date).run();
 }
+
+/**
+ * Rebuild `nutrition_log` for a single (user, date) from the ground-truth
+ * source rows: sum of `meals` macros + sum of `nutrition_entries` amounts
+ * by type. Overwrites whatever was in `nutrition_log` for that date.
+ *
+ * Use when the log has drifted from the underlying rows (e.g. due to a
+ * historical bug in the add/subtract path) or when you want a "recompute
+ * from scratch" guarantee after a batch operation.
+ *
+ * Returns the freshly-computed totals.
+ */
+export async function reconcileNutritionLog(db, userId, date) {
+  // Sum cached meal totals for the date.
+  const meals = await db.prepare(
+    `SELECT COALESCE(SUM(calories),  0) AS calories,
+            COALESCE(SUM(protein_g), 0) AS protein_g,
+            COALESCE(SUM(carbs_g),   0) AS carbs_g,
+            COALESCE(SUM(fat_g),     0) AS fat_g,
+            COALESCE(SUM(fiber_g),   0) AS fiber_g
+       FROM meals
+      WHERE user_id = ? AND date = ?`
+  ).bind(userId, date).first();
+
+  // Sum scalar entries by type for the date.
+  const entries = await db.prepare(
+    `SELECT entry_type, COALESCE(SUM(amount), 0) AS total
+       FROM nutrition_entries
+      WHERE user_id = ?
+        AND date(logged_at) = ?
+      GROUP BY entry_type`
+  ).bind(userId, date).all();
+
+  let proteinFromEntries = 0;
+  let waterFromEntries = 0;
+  let creatineFromEntries = 0;
+  for (const row of (entries.results || [])) {
+    if (row.entry_type === 'protein')  proteinFromEntries  = Number(row.total) || 0;
+    if (row.entry_type === 'water')    waterFromEntries    = Number(row.total) || 0;
+    if (row.entry_type === 'creatine') creatineFromEntries = Number(row.total) || 0;
+  }
+
+  const mealMacros = normalizeMacros({
+    calories:  meals?.calories,
+    protein_g: meals?.protein_g,
+    carbs_g:   meals?.carbs_g,
+    fat_g:     meals?.fat_g,
+    fiber_g:   meals?.fiber_g
+  });
+
+  const totals = {
+    calories:      mealMacros.calories,
+    protein_grams: Math.round((mealMacros.protein_g + proteinFromEntries) * 10) / 10,
+    carbs_grams:   mealMacros.carbs_g,
+    fat_grams:     mealMacros.fat_g,
+    fiber_grams:   mealMacros.fiber_g,
+    water_ml:      Math.round(waterFromEntries),
+    creatine_grams: Math.round(creatineFromEntries * 10) / 10
+  };
+
+  // UPSERT the reconciled row. If none exists yet, this creates it.
+  await db.prepare(
+    `INSERT INTO nutrition_log
+       (user_id, date, calories, protein_grams, carbs_grams, fat_grams,
+        fiber_grams, water_ml, creatine_grams, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+     ON CONFLICT(user_id, date) DO UPDATE SET
+       calories        = excluded.calories,
+       protein_grams   = excluded.protein_grams,
+       carbs_grams     = excluded.carbs_grams,
+       fat_grams       = excluded.fat_grams,
+       fiber_grams     = excluded.fiber_grams,
+       water_ml        = excluded.water_ml,
+       creatine_grams  = excluded.creatine_grams,
+       updated_at      = CURRENT_TIMESTAMP`
+  ).bind(
+    userId, date,
+    totals.calories, totals.protein_grams, totals.carbs_grams,
+    totals.fat_grams, totals.fiber_grams,
+    totals.water_ml, totals.creatine_grams
+  ).run();
+
+  return totals;
+}
+
+/**
+ * Reconcile nutrition_log for every date in a window (inclusive). Iterates
+ * in JS so each date is fully independent — one bad row doesn't taint
+ * the others. Returns an object keyed by date with the reconciled totals.
+ */
+export async function reconcileNutritionLogRange(db, userId, startDate, endDate) {
+  // Enumerate candidate dates from the union of meals.date + entries.logged_at
+  // (falling back to the raw range if the user asked for a specific window).
+  const datesResult = await db.prepare(
+    `SELECT DISTINCT date FROM (
+       SELECT date AS date          FROM meals
+        WHERE user_id = ? AND date >= ? AND date <= ?
+       UNION
+       SELECT date(logged_at) AS date FROM nutrition_entries
+        WHERE user_id = ? AND date(logged_at) >= ? AND date(logged_at) <= ?
+       UNION
+       SELECT date AS date          FROM nutrition_log
+        WHERE user_id = ? AND date >= ? AND date <= ?
+     )
+     ORDER BY date ASC`
+  ).bind(
+    userId, startDate, endDate,
+    userId, startDate, endDate,
+    userId, startDate, endDate
+  ).all();
+
+  const reconciled = {};
+  for (const row of (datesResult.results || [])) {
+    if (!row.date) continue;
+    reconciled[row.date] = await reconcileNutritionLog(db, userId, row.date);
+  }
+  return reconciled;
+}

--- a/tests/unit/nutrition-ledger.test.js
+++ b/tests/unit/nutrition-ledger.test.js
@@ -8,7 +8,9 @@ import {
   subtractFromNutritionLog,
   addEntryToLog,
   subtractEntryFromLog,
-  entryColumnFor
+  entryColumnFor,
+  reconcileNutritionLog,
+  reconcileNutritionLogRange
 } from '../../src/utils/nutrition-ledger.js';
 
 /**
@@ -233,5 +235,138 @@ describe('addEntryToLog / subtractEntryFromLog', () => {
     await addEntryToLog(db, 1, '2026-04-21', 'protein', 0);
     await addEntryToLog(db, 1, '2026-04-21', 'protein', -5);
     expect(db.calls).toHaveLength(0);
+  });
+});
+
+describe('reconcileNutritionLog', () => {
+  /**
+   * Specialized mock that returns different results for each prepared
+   * statement based on which SQL fragment it contains. Lets us simulate
+   * meals + entries + upsert in a single reconcile call.
+   */
+  function reconcileMock({ mealTotals, entryRows }) {
+    const calls = [];
+    return {
+      calls,
+      prepare(sql) {
+        const call = { sql, params: null };
+        calls.push(call);
+        return {
+          bind(...params) {
+            call.params = params;
+            return {
+              first: async () => {
+                if (sql.includes('FROM meals')) return mealTotals;
+                return null;
+              },
+              all: async () => {
+                if (sql.includes('FROM nutrition_entries')) {
+                  return { results: entryRows };
+                }
+                if (sql.includes('FROM (')) {
+                  // Range enumeration query
+                  return { results: [] };
+                }
+                return { results: [] };
+              },
+              run: async () => ({ success: true })
+            };
+          }
+        };
+      }
+    };
+  }
+
+  it('sums meals + per-type entries and UPSERTs the reconciled totals', async () => {
+    const db = reconcileMock({
+      mealTotals: { calories: 474, protein_g: 56.5, carbs_g: 10.8, fat_g: 22, fiber_g: 0 },
+      entryRows: [
+        { entry_type: 'protein',  total: 30 },
+        { entry_type: 'water',    total: 500 },
+        { entry_type: 'creatine', total: 5 }
+      ]
+    });
+
+    const totals = await reconcileNutritionLog(db, 1, '2026-04-21');
+
+    // Expect: 3 prepare()s — meals sum, entries group-by, upsert
+    expect(db.calls.length).toBe(3);
+
+    // Calories/carbs/fat/fiber come from meals only.
+    expect(totals.calories).toBe(474);
+    expect(totals.carbs_grams).toBe(10.8);
+    expect(totals.fat_grams).toBe(22);
+    expect(totals.fiber_grams).toBe(0);
+
+    // Protein is sum of meals + protein entries (56.5 + 30 = 86.5).
+    expect(totals.protein_grams).toBe(86.5);
+
+    // Water and creatine come from entries only.
+    expect(totals.water_ml).toBe(500);
+    expect(totals.creatine_grams).toBe(5);
+
+    // Verify the upsert uses excluded.* (overwrites, not adds).
+    const upsert = db.calls[2];
+    expect(upsert.sql).toMatch(/ON CONFLICT\(user_id, date\) DO UPDATE SET/);
+    expect(upsert.sql).toMatch(/protein_grams\s+=\s+excluded\.protein_grams/);
+    expect(upsert.params.slice(0, 2)).toEqual([1, '2026-04-21']);
+  });
+
+  it('handles days with meals only (no entries) correctly', async () => {
+    const db = reconcileMock({
+      mealTotals: { calories: 300, protein_g: 25, carbs_g: 40, fat_g: 10, fiber_g: 3 },
+      entryRows: []
+    });
+    const totals = await reconcileNutritionLog(db, 1, '2026-04-21');
+    expect(totals.protein_grams).toBe(25);
+    expect(totals.water_ml).toBe(0);
+    expect(totals.creatine_grams).toBe(0);
+  });
+
+  it('handles days with entries only (no meals) correctly', async () => {
+    const db = reconcileMock({
+      mealTotals: null, // no meals
+      entryRows: [{ entry_type: 'protein', total: 40 }]
+    });
+    const totals = await reconcileNutritionLog(db, 1, '2026-04-21');
+    expect(totals.calories).toBe(0);
+    expect(totals.protein_grams).toBe(40);
+    expect(totals.carbs_grams).toBe(0);
+  });
+});
+
+describe('reconcileNutritionLogRange', () => {
+  it('enumerates distinct dates from meals/entries/log then reconciles each', async () => {
+    const dates = ['2026-04-20', '2026-04-21'];
+    let enumerateCalled = false;
+    const db = {
+      calls: [],
+      prepare(sql) {
+        this.calls.push(sql);
+        return {
+          bind: () => ({
+            first: async () => {
+              if (sql.includes('FROM meals\n')) {
+                // Per-date reconcile — return some macros
+                return { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0, fiber_g: 0 };
+              }
+              return null;
+            },
+            all: async () => {
+              if (sql.includes('FROM (') && !enumerateCalled) {
+                enumerateCalled = true;
+                return { results: dates.map((d) => ({ date: d })) };
+              }
+              if (sql.includes('FROM nutrition_entries')) return { results: [] };
+              return { results: [] };
+            },
+            run: async () => ({ success: true })
+          })
+        };
+      }
+    };
+
+    const result = await reconcileNutritionLogRange(db, 1, '2026-04-15', '2026-04-21');
+    expect(Object.keys(result)).toEqual(dates);
   });
 });


### PR DESCRIPTION
## Summary

Heals the ring-vs-entries discrepancy the user reported after PR #34 landed. Example they shared: **rings show 139g protein but the 14-day entries modal only sums to 56g** — an 83g gap.

Root cause: accumulated historical drift in the `nutrition_log` aggregate table. Before PR #34:
- `DELETE /meals/:id` only subtracted `protein_grams` (not calories/carbs/fat/fiber), so deleting meals drifted the ring upward on every other macro.
- Saved-meal logs with no `meal_foods` children produced `SUM(meal_foods.*) = 0` on delete, so nothing was subtracted at all — full drift of all 5 macros per historical delete.

PR #34 fixed those paths going forward but didn't rebuild the past. This PR closes the loop.

## New helpers

`src/utils/nutrition-ledger.js`:

- `reconcileNutritionLog(db, userId, date)` — overwrites `nutrition_log` for a single day from ground truth: `meals.{calories, protein_g, carbs_g, fat_g, fiber_g}` + `nutrition_entries.amount` grouped by `entry_type`.
- `reconcileNutritionLogRange(db, userId, start, end)` — enumerates distinct dates across meals/entries/log within the range and reconciles each independently.

## New endpoints

| | |
|---|---|
| `POST /nutrition/reconcile?date=YYYY-MM-DD` | Reconcile one day |
| `POST /nutrition/reconcile?start_date=…&end_date=…` | Reconcile a range |
| `POST /nutrition/reconcile` | Default: last 30 days |
| `PATCH /nutrition/logs/:date` | Direct edit of protein/water/creatine totals (the "Edit daily log" modal in the UI has been calling this for a while — previously silent 404) |
| `DELETE /nutrition/logs/:date` | Direct delete of the daily log row (same story — UI called, backend ignored) |

The two direct-edit endpoints are escape hatches. A subsequent `/reconcile` will overwrite any manual edit with the recomputed sum from underlying rows — which is exactly right for "fix the rings" workflows.

## UI

The **Last 14 Days** card gains a subtle **Recalculate** button next to **View all entries**. Clicking it hits `POST /nutrition/reconcile` (30-day default), toasts the number of days fixed, and refreshes the screen. Tooltip: *"If the progress rings ever disagree with your logged entries, this rebuilds the daily totals from the source."*

## Tests

**4 new** in `tests/unit/nutrition-ledger.test.js`:
- `reconcileNutritionLog` sums meals + per-type entries, UPSERTs canonical totals, handles protein-from-both-sources
- days with meals only (no entries) produce correct macros
- days with entries only (no meals) produce correct macros without synthesizing meal data
- `reconcileNutritionLogRange` enumerates distinct dates from the union and reconciles each

Full suite: **134 / 134 pass**. `wrangler deploy --dry-run` clean.

## Post-merge action

I'll run a one-shot SQL reconcile directly against remote D1 **after this deploys** so the user's current rings match immediately without having to click the button. Going forward, the button is their self-service knob.