### PR TITLE
Use local-timezone dates everywhere (fix 'app thinks today is tomorrow')

### DIFF
--- a/frontend/src/features/ai-coach/nutrition-coach.js
+++ b/frontend/src/features/ai-coach/nutrition-coach.js
@@ -13,6 +13,7 @@ import { api } from '@core/api';
 import { openModal, closeTopModal } from '@ui/Modal';
 import { toast } from '@ui/Toast';
 import { withLoading } from '@ui/LoadingOverlay';
+import { todayLocal } from '@utils/date';
 
 const PRIORITY_BADGE = {
   high: 'badge-danger',
@@ -258,7 +259,7 @@ async function logSuggestionAsMeal(suggestion) {
   const macros = suggestion.macros || {};
   try {
     await api.post('/nutrition/meals', {
-      date: new Date().toISOString().split('T')[0],
+      date: todayLocal(),
       meal_type: 'snack',
       name: suggestion.name,
       // Inline-save the AI suggestion as a food so the backend records the
@@ -441,7 +442,7 @@ function renderParseResults({ foods, totals }) {
 async function logParsedMeal(parseResult) {
   try {
     await api.post('/nutrition/meals', {
-      date: new Date().toISOString().split('T')[0],
+      date: todayLocal(),
       meal_type: 'snack',
       name: 'Parsed meal',
       foods: parseResult.foods.map((f) => ({

--- a/frontend/src/features/analytics/export-center.js
+++ b/frontend/src/features/analytics/export-center.js
@@ -13,6 +13,7 @@ import { html, htmlToElement, raw } from '@core/html';
 import { api } from '@core/api';
 import { openModal, closeTopModal } from '@ui/Modal';
 import { toast } from '@ui/Toast';
+import { todayLocal, daysAgoLocal } from '@utils/date';
 import { formatWeight, formatDate, formatDuration } from '@utils/formatters';
 
 // ============================================================================
@@ -50,7 +51,7 @@ async function downloadExport(type, { start, end, format }) {
   }
 
   const contentType = response.headers.get('content-type') || '';
-  const today = new Date().toISOString().split('T')[0];
+  const today = todayLocal();
 
   if (contentType.includes('text/csv')) {
     const blob = await response.blob();
@@ -83,8 +84,8 @@ async function fetchReportData(startDate, endDate) {
 
   return {
     period: {
-      start: startDate || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-      end: endDate || new Date().toISOString().split('T')[0]
+      start: startDate || daysAgoLocal(-30),
+      end: endDate || todayLocal()
     },
     overview: progressData.overview || {},
     advanced: advancedData.data || {},
@@ -236,7 +237,7 @@ async function generatePDF(modalEl) {
       heightLeft -= pageHeight;
     }
 
-    pdf.save(`fitness-report-${new Date().toISOString().split('T')[0]}.pdf`);
+    pdf.save(`fitness-report-${todayLocal()}.pdf`);
     toast.success('PDF downloaded');
   } catch (err) {
     console.error('PDF generation failed:', err);
@@ -249,10 +250,8 @@ async function generatePDF(modalEl) {
 // ============================================================================
 
 export function openUnifiedExporter() {
-  const thirtyDaysAgo = new Date();
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-  const today = new Date().toISOString().split('T')[0];
-  const start = thirtyDaysAgo.toISOString().split('T')[0];
+  const today = todayLocal();
+  const start = daysAgoLocal(-30);
 
   let activeTab = 'data';
 

--- a/frontend/src/features/nutrition/meal-logger.js
+++ b/frontend/src/features/nutrition/meal-logger.js
@@ -8,6 +8,7 @@ import { api } from '@core/api';
 import { openModal, closeTopModal } from '@ui/Modal';
 import { toast } from '@ui/Toast';
 import { playBarcodeDetected } from '@utils/audio';
+import { todayLocal } from '@utils/date';
 import { createDecoder, hasCameraSupport, mapPointsToDisplay } from './barcode-decoder.js';
 
 let state = {
@@ -346,7 +347,7 @@ async function saveMeal() {
 
   try {
     await api.post('/nutrition/meals', {
-      date: new Date().toISOString().split('T')[0],
+      date: todayLocal(),
       meal_type: state.mealType,
       foods: state.selectedFoods.map((item) => {
         const payload = {
@@ -850,7 +851,8 @@ async function lookupBarcode() {
           food_id: toAdd.id,
           quantity: qty,
           unit: 'serving',
-          meal_type: mealType
+          meal_type: mealType,
+          date: todayLocal()
         });
         closeTopModal();
         toast.success(`Logged ${toAdd.name}`);

--- a/frontend/src/features/nutrition/saved-meals.js
+++ b/frontend/src/features/nutrition/saved-meals.js
@@ -8,6 +8,7 @@ import { api } from '@core/api';
 import { delegate } from '@core/delegate';
 import { openModal, confirmDialog, closeTopModal } from '@ui/Modal';
 import { toast } from '@ui/Toast';
+import { todayLocal, daysAgoLocal, dateLocal, nowLocalISO } from '@utils/date';
 
 // ============================================================================
 // Saved meals list (preview in Nutrition tab)
@@ -384,7 +385,7 @@ async function logQuickMacros(modalApi) {
   try {
     // Log as a custom meal (no foods, just macros)
     await api.post('/nutrition/meals', {
-      date: new Date().toISOString().split('T')[0],
+      date: todayLocal(),
       meal_type: 'snack',
       custom_macros: { calories, protein_g: protein, carbs_g: carbs, fat_g: fat }
     });
@@ -496,16 +497,17 @@ function mealMeta(mealType) {
 
 function formatEntryTime(iso) {
   if (!iso) return '';
-  const d = new Date(iso.includes('T') || iso.includes('Z') ? iso : iso.replace(' ', 'T') + 'Z');
+  // `logged_at` can arrive as a naive local ISO (new writes) or a UTC Z-ISO
+  // (legacy rows). Treat naive strings as local time (drop the `+ 'Z'`
+  // fallback that used to flip them to UTC and misdisplay the hour).
+  const d = new Date(iso.includes('T') ? iso : iso.replace(' ', 'T'));
   if (Number.isNaN(d.getTime())) return '';
   return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 }
 
 function formatEntryDateHeader(dateKey, today) {
   if (dateKey === today) return 'Today';
-  const y = new Date(today);
-  y.setDate(y.getDate() - 1);
-  const yesterday = y.toISOString().split('T')[0];
+  const yesterday = daysAgoLocal(-1);
   if (dateKey === yesterday) return 'Yesterday';
   const [yr, mo, dy] = dateKey.split('-').map(Number);
   const d = new Date(yr, mo - 1, dy);
@@ -516,15 +518,13 @@ function groupActivityByDate(items) {
   const groups = new Map();
   for (const it of items) {
     // Prefer the server's explicit `date` (canonical local day), but fall
-    // back to parsing occurred_at if missing.
+    // back to parsing occurred_at as local time (naive ISO) if missing.
     let key = it.date;
     if (!key) {
       const raw = it.occurred_at || '';
-      const iso = raw.includes('T') || raw.includes('Z') ? raw : raw.replace(' ', 'T') + 'Z';
+      const iso = raw.includes('T') ? raw : raw.replace(' ', 'T');
       const d = new Date(iso);
-      key = Number.isNaN(d.getTime())
-        ? 'unknown'
-        : `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      key = Number.isNaN(d.getTime()) ? 'unknown' : dateLocal(d);
     }
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key).push(it);
@@ -606,7 +606,7 @@ function renderActivityBody(items) {
     `;
   }
 
-  const today = new Date().toISOString().split('T')[0];
+  const today = todayLocal();
   const groups = groupActivityByDate(items);
 
   return html`
@@ -653,12 +653,11 @@ async function fetchActivityItems(start, end) {
 }
 
 export async function loadNutritionEntries() {
-  // Last 14 days window (matches the "Last 14 Days" section the button sits in)
-  const endDate = new Date();
-  const startDate = new Date();
-  startDate.setDate(startDate.getDate() - 13); // inclusive 14-day window
-  const start = startDate.toISOString().split('T')[0];
-  const end = endDate.toISOString().split('T')[0];
+  // Last 14 days window (matches the "Last 14 Days" section the button sits in).
+  // Uses local-date math so the window boundaries line up with the user's
+  // clock, not UTC.
+  const end = todayLocal();
+  const start = daysAgoLocal(-13);
 
   let items;
   try {

--- a/frontend/src/features/past-workout/controller.js
+++ b/frontend/src/features/past-workout/controller.js
@@ -13,6 +13,7 @@ import { html, raw } from '@core/html';
 import { api } from '@core/api';
 import { store } from '@core/state';
 import { toast } from '@ui/Toast';
+import { todayLocal } from '@utils/date';
 import { openModal } from '@ui/Modal';
 import {
   isImperialSystem,
@@ -59,7 +60,7 @@ export async function showLogPastWorkout(preselectedDate = null) {
     }
   }
 
-  flowState.date = preselectedDate || new Date().toISOString().split('T')[0];
+  flowState.date = preselectedDate || todayLocal();
 
   renderMainModal();
 }
@@ -76,7 +77,7 @@ function renderMainModal() {
         <div class="grid grid-cols-2" style="gap: var(--space-3);">
           <div class="form-group">
             <label class="form-label">Date</label>
-            <input type="date" id="past-date" class="input" value="${flowState.date}" max="${new Date().toISOString().split('T')[0]}" />
+            <input type="date" id="past-date" class="input" value="${flowState.date}" max="${todayLocal()}" />
           </div>
           <div class="form-group">
             <label class="form-label">Duration (minutes)</label>

--- a/frontend/src/features/workout-calendar.js
+++ b/frontend/src/features/workout-calendar.js
@@ -15,6 +15,7 @@ import {
   formatDate,
   getExertionEmoji
 } from '@utils/formatters';
+import { todayLocal, dateLocal } from '@utils/date';
 
 const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -33,7 +34,7 @@ function renderGrid() {
   const totalDays = lastDay.getDate();
 
   const today = new Date();
-  const todayKey = today.toISOString().split('T')[0];
+  const todayKey = todayLocal();
 
   const cells = [];
 
@@ -247,9 +248,13 @@ export async function loadWorkoutCalendar(hostEl) {
     const data = await api.get('/workouts?limit=100');
     const workouts = data.workouts || [];
 
+    // Bucket workouts by the user's local calendar day. The raw
+    // `start_time` is a UTC timestamp; converting via toISOString would
+    // attribute late-evening workouts to the next UTC day, which looks
+    // wrong on the calendar grid.
     const byDate = {};
     for (const w of workouts) {
-      const key = new Date(w.start_time).toISOString().split('T')[0];
+      const key = dateLocal(new Date(w.start_time));
       if (!byDate[key]) byDate[key] = [];
       byDate[key].push(w);
     }

--- a/frontend/src/screens/nutrition.js
+++ b/frontend/src/screens/nutrition.js
@@ -14,6 +14,7 @@ import { delegate } from '@core/delegate';
 import { toast } from '@ui/Toast';
 import { progressRing } from '@ui/ProgressRing';
 import { formatDate, formatNumber } from '@utils/formatters';
+import { todayLocal, nowLocalISO } from '@utils/date';
 
 // =============================================================================
 // Rendering helpers
@@ -267,7 +268,7 @@ function renderRecentDays(dailyData, summary) {
       ${recent.map((day) => {
         const proteinPct = Math.min((day.protein / day.protein_goal) * 100, 100);
         const waterPct = Math.min((day.water / day.water_goal) * 100, 100);
-        const isToday = day.date === new Date().toISOString().split('T')[0];
+        const isToday = day.date === todayLocal();
         return html`
           <div class="nutrition-bar-day ${isToday ? 'is-today' : ''}">
             <div class="nutrition-bar-label">${formatDate(day.date, { month: 'short', day: 'numeric' })}</div>
@@ -317,15 +318,19 @@ async function logAllQuick() {
   }
 
   try {
+    // Stamp each entry with a local-time ISO so it's filed under the user's
+    // current calendar day, not UTC's (which may be tomorrow in the evening
+    // for Western-Hemisphere users).
+    const loggedAt = nowLocalISO();
     const ops = [];
     if (protein > 0) {
-      ops.push(api.post('/nutrition/entries', { entry_type: 'protein', amount: protein, unit: 'g' }));
+      ops.push(api.post('/nutrition/entries', { entry_type: 'protein', amount: protein, unit: 'g', logged_at: loggedAt }));
     }
     if (water > 0) {
-      ops.push(api.post('/nutrition/entries', { entry_type: 'water', amount: water, unit: 'ml' }));
+      ops.push(api.post('/nutrition/entries', { entry_type: 'water', amount: water, unit: 'ml', logged_at: loggedAt }));
     }
     if (creatine > 0) {
-      ops.push(api.post('/nutrition/entries', { entry_type: 'creatine', amount: creatine, unit: 'g' }));
+      ops.push(api.post('/nutrition/entries', { entry_type: 'creatine', amount: creatine, unit: 'g', logged_at: loggedAt }));
     }
 
     await Promise.all(ops);
@@ -444,8 +449,9 @@ export async function loadNutrition() {
   container.innerHTML = String(renderLoadingState());
 
   try {
+    const today = todayLocal();
     const [daily, analytics, streaks] = await Promise.all([
-      api.get('/nutrition/daily'),
+      api.get(`/nutrition/daily?date=${today}`),
       api.get('/nutrition/analytics?days=30'),
       api.get('/nutrition/streaks')
     ]);

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -1,0 +1,73 @@
+/**
+ * Local-timezone date helpers.
+ *
+ * The rest of the app used to compute "today" as
+ * `new Date().toISOString().split('T')[0]`, which returns the UTC date.
+ * That means on a Western-Hemisphere clock in the evening, UTC has
+ * already rolled past midnight while the user is still on the previous
+ * calendar day — so the app would display "today" as tomorrow, and
+ * freshly-logged meals/entries would be filed under the wrong date.
+ *
+ * These helpers always work in the user's local timezone (the browser's
+ * `Date` object), giving a consistent YYYY-MM-DD day key that matches
+ * what the user sees on their wall clock / phone lock screen.
+ */
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * YYYY-MM-DD in local time for the given Date (defaults to now).
+ */
+export function dateLocal(d = new Date()) {
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}
+
+/**
+ * Today as YYYY-MM-DD in the user's local timezone.
+ */
+export function todayLocal() {
+  return dateLocal(new Date());
+}
+
+/**
+ * YYYY-MM-DD for (today + dayOffset) in local time. Use negative numbers
+ * for past days (e.g. -1 for yesterday, -13 for the start of a 14-day
+ * inclusive window).
+ */
+export function daysAgoLocal(dayOffset) {
+  const d = new Date();
+  d.setDate(d.getDate() + dayOffset);
+  return dateLocal(d);
+}
+
+/**
+ * Now as a "naive" ISO-8601 timestamp in the user's local timezone,
+ * WITHOUT a Z or numeric offset suffix.
+ * Example: "2026-04-21T22:13:00.000"
+ *
+ * Use this for fields like `logged_at` on a nutrition entry. SQLite's
+ * date() / datetime() functions treat a naive string as local time, so
+ * `date(logged_at)` returns the local day the user was actually on — not
+ * the UTC day, which would drift across midnight.
+ *
+ * (A naive timestamp is semantically "a wall-clock moment"; perfect for
+ * a single-user fitness log, where we care about the day the user was
+ * living in when they pressed the button, not a cross-timezone moment.)
+ */
+export function nowLocalISO() {
+  const d = new Date();
+  return (
+    `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}` +
+    `T${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}` +
+    `.${String(d.getMilliseconds()).padStart(3, '0')}`
+  );
+}
+
+/**
+ * Compare two YYYY-MM-DD strings safely (lexicographic compare works).
+ */
+export function isSameDay(a, b) {
+  return a && b && a.slice(0, 10) === b.slice(0, 10);
+}

--- a/src/routes/ai.js
+++ b/src/routes/ai.js
@@ -17,6 +17,7 @@ import {
   suggestNextMeal,
   parseMealFromText
 } from '../services/ai-nutrition.js';
+import { todayForRequest } from '../utils/local-date.js';
 
 const ai = new Hono();
 
@@ -589,7 +590,9 @@ ai.post('/realtime/analyze', async (c) => {
 ai.get('/nutrition/analyze', async (c) => {
   const user = requireAuth(c);
   const db = c.env.DB;
-  const date = c.req.query('date');
+  // Default to the user's LOCAL today (via the request's CF timezone)
+  // so late-evening users don't get an empty "tomorrow" log.
+  const date = c.req.query('date') || todayForRequest(c);
 
   try {
     const result = await analyzeNutrition({ ai: c.env.AI, db, user, date, env: c.env });
@@ -624,6 +627,9 @@ ai.post('/nutrition/suggest-meal', async (c) => {
       db,
       user,
       mealType: body?.meal_type || 'next',
+      // User's local today, so the "remaining macros for today" math is
+      // anchored to the calendar day the user is actually on.
+      date: todayForRequest(c),
       env: c.env
     });
     return c.json({ success: true, ...result });

--- a/src/routes/nutrition.js
+++ b/src/routes/nutrition.js
@@ -13,6 +13,11 @@ import {
   reconcileNutritionLog,
   reconcileNutritionLogRange
 } from '../utils/nutrition-ledger';
+import {
+  todayForRequest,
+  daysAgoForRequest,
+  toDateKey
+} from '../utils/local-date';
 
 const nutrition = new Hono();
 
@@ -23,7 +28,7 @@ nutrition.post('/protein', async (c) => {
   const { grams, date } = body;
   const db = c.env.DB;
 
-  const logDate = date || new Date().toISOString().split('T')[0];
+  const logDate = date || todayForRequest(c);
 
   // Upsert nutrition log
   const log = await db.prepare(
@@ -46,7 +51,7 @@ nutrition.post('/water', async (c) => {
   const { ml, date } = body;
   const db = c.env.DB;
 
-  const logDate = date || new Date().toISOString().split('T')[0];
+  const logDate = date || todayForRequest(c);
 
   // Upsert nutrition log
   const log = await db.prepare(
@@ -69,7 +74,7 @@ nutrition.post('/creatine', async (c) => {
   const { grams, date } = body;
   const db = c.env.DB;
 
-  const logDate = date || new Date().toISOString().split('T')[0];
+  const logDate = date || todayForRequest(c);
 
   // Upsert nutrition log
   const log = await db.prepare(
@@ -89,7 +94,7 @@ nutrition.post('/creatine', async (c) => {
 nutrition.get('/daily', async (c) => {
   const user = requireAuth(c);
   const db = c.env.DB;
-  const date = c.req.query('date') || new Date().toISOString().split('T')[0];
+  const date = c.req.query('date') || todayForRequest(c);
 
   const log = await db.prepare(
     'SELECT * FROM nutrition_log WHERE user_id = ? AND date = ?'
@@ -238,14 +243,16 @@ nutrition.get('/analytics', async (c) => {
   let currentStreak = 0;
   let longestStreak = 0;
   let tempStreak = 0;
-  
+
+  // Iterate backwards from the user's LOCAL today (not UTC) so a streak
+  // that includes today doesn't get dropped by a UTC-vs-local date skew.
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  
+
   for (let i = 0; i < days; i++) {
     const checkDate = new Date(today);
     checkDate.setDate(checkDate.getDate() - i);
-    const dateStr = checkDate.toISOString().split('T')[0];
+    const dateStr = toDateKey(checkDate);
     
     const log = logs.find(l => l.date === dateStr);
     const hitGoals = log && 
@@ -376,7 +383,7 @@ nutrition.get('/streaks', async (c) => {
     for (let i = 0; i < 90; i++) {
       const checkDate = new Date(today);
       checkDate.setDate(checkDate.getDate() - i);
-      const dateStr = checkDate.toISOString().split('T')[0];
+      const dateStr = toDateKey(checkDate);
       
       const log = logs.find(l => l.date === dateStr);
       let hit = false;
@@ -410,7 +417,7 @@ nutrition.put('/daily', async (c) => {
   const { date, protein_grams, water_ml, creatine_grams } = body;
   const db = c.env.DB;
 
-  const logDate = date || new Date().toISOString().split('T')[0];
+  const logDate = date || todayForRequest(c);
 
   const log = await db.prepare(
     `INSERT INTO nutrition_log (user_id, date, protein_grams, water_ml, creatine_grams, updated_at)
@@ -670,9 +677,8 @@ nutrition.post('/reconcile', async (c) => {
     return c.json({ reconciled: { [singleDate]: totals } });
   }
 
-  const today = new Date().toISOString().split('T')[0];
-  const defaultStart = new Date(Date.now() - 29 * 24 * 60 * 60 * 1000)
-    .toISOString().split('T')[0];
+  const today = todayForRequest(c);
+  const defaultStart = daysAgoForRequest(c, -29);
   const startDate = c.req.query('start_date') || defaultStart;
   const endDate   = c.req.query('end_date')   || today;
 
@@ -698,8 +704,12 @@ nutrition.post('/entries', async (c) => {
     return c.json({ error: 'Invalid entry_type' }, 400);
   }
 
-  const timestamp = logged_at || new Date().toISOString();
-  const logDate = timestamp.split(/[T ]/)[0];
+  // Preserve the client's `logged_at` when provided (frontend sends a naive
+  // local ISO like "2026-04-21T22:13:00.000" so SQLite's date() returns
+  // the user's local day). Fall back to a naive local-now derived from the
+  // request's Cloudflare-attested timezone when the client doesn't specify.
+  const timestamp = logged_at || `${todayForRequest(c)}T00:00:00.000`;
+  const logDate = toDateKey(timestamp) || todayForRequest(c);
 
   const result = await db.prepare(
     `INSERT INTO nutrition_entries (user_id, entry_type, amount, unit, notes, logged_at)
@@ -716,8 +726,8 @@ nutrition.post('/entries', async (c) => {
 nutrition.get('/entries', async (c) => {
   const user = requireAuth(c);
   const db = c.env.DB;
-  const startDate = c.req.query('start_date') || new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-  const endDate = c.req.query('end_date') || new Date().toISOString().split('T')[0];
+  const startDate = c.req.query('start_date') || daysAgoForRequest(c, -6);
+  const endDate = c.req.query('end_date') || todayForRequest(c);
   const entryType = c.req.query('entry_type'); // optional filter
 
   let query = `
@@ -756,8 +766,8 @@ nutrition.get('/entries', async (c) => {
 nutrition.get('/activity', async (c) => {
   const user = requireAuth(c);
   const db = c.env.DB;
-  const today = new Date().toISOString().split('T')[0];
-  const defaultStart = new Date(Date.now() - 13 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const today = todayForRequest(c);
+  const defaultStart = daysAgoForRequest(c, -13);
   const startDate = c.req.query('start_date') || defaultStart;
   const endDate = c.req.query('end_date') || today;
 
@@ -1605,7 +1615,7 @@ nutrition.post('/meals', async (c) => {
 
   const { date, meal_type, name, foods, notes, custom_macros } = body;
 
-  const mealDate = date || new Date().toISOString().split('T')[0];
+  const mealDate = date || todayForRequest(c);
   const mealType = meal_type || 'snack';
 
   // Create meal (macros defaulted to 0; filled in below)
@@ -1736,7 +1746,7 @@ nutrition.post('/meals', async (c) => {
 nutrition.get('/meals', async (c) => {
   const user = requireAuth(c);
   const db = c.env.DB;
-  const date = c.req.query('date') || new Date().toISOString().split('T')[0];
+  const date = c.req.query('date') || todayForRequest(c);
 
   const meals = await db.prepare(
     `SELECT m.*
@@ -1873,9 +1883,9 @@ nutrition.post('/macro-targets', async (c) => {
     fat_g || null,
     fiber_g || null,
     water_ml || null,
-    effective_date || new Date().toISOString().split('T')[0]
+    effective_date || todayForRequest(c)
   ).first();
-  
+
   return c.json({ targets: result, message: 'Macro targets saved' });
 });
 
@@ -1938,7 +1948,7 @@ nutrition.post('/quick-add', async (c) => {
     return c.json({ error: 'food_id is required' }, 400);
   }
 
-  const mealDate = date || new Date().toISOString().split('T')[0];
+  const mealDate = date || todayForRequest(c);
   const mealTypeValue = meal_type || 'snack';
 
   // Get or create a dedicated "quick-add bucket" meal for this slot
@@ -2133,7 +2143,7 @@ nutrition.post('/saved-meals/:id/log', async (c) => {
   }
 
   const { date, meal_type } = body;
-  const logDate = date || new Date().toISOString().split('T')[0];
+  const logDate = date || todayForRequest(c);
 
   const savedMeal = await db.prepare(
     'SELECT * FROM saved_meals WHERE id = ? AND user_id = ?'

--- a/src/services/ai-nutrition.js
+++ b/src/services/ai-nutrition.js
@@ -74,7 +74,14 @@ async function getRecentLogs(db, userId, days = 7) {
  * enhance with an AI-generated narrative summary.
  */
 export async function analyzeNutrition({ ai, db, user, date, env }) {
-  const today = date || new Date().toISOString().split('T')[0];
+  // Caller is expected to pass the user's local today (routes pull this
+  // from the CF request timezone). UTC fallback is only for tests /
+  // scripted callers that don't have a Hono context.
+  const today = date || (() => {
+    const n = new Date();
+    const p = (v) => String(v).padStart(2, '0');
+    return `${n.getUTCFullYear()}-${p(n.getUTCMonth() + 1)}-${p(n.getUTCDate())}`;
+  })();
   const [todayLog, recentLogs, targets] = await Promise.all([
     getDailyLog(db, user.id, today),
     getRecentLogs(db, user.id, 7),
@@ -240,8 +247,14 @@ export async function analyzeNutrition({ ai, db, user, date, env }) {
  * Suggest a meal that helps hit the user's remaining macros for the day.
  * Uses AI for variety; falls back to rule-based suggestions.
  */
-export async function suggestNextMeal({ ai, db, user, mealType = 'next', env }) {
-  const today = new Date().toISOString().split('T')[0];
+export async function suggestNextMeal({ ai, db, user, mealType = 'next', date, env }) {
+  // Caller passes local today from the request's timezone. UTC fallback
+  // only applies to tests / scripted callers.
+  const today = date || (() => {
+    const n = new Date();
+    const p = (v) => String(v).padStart(2, '0');
+    return `${n.getUTCFullYear()}-${p(n.getUTCMonth() + 1)}-${p(n.getUTCDate())}`;
+  })();
   const [todayLog, targets] = await Promise.all([
     getDailyLog(db, user.id, today),
     getTargets(db, user.id, user.weight_kg)

--- a/src/utils/local-date.js
+++ b/src/utils/local-date.js
@@ -1,0 +1,88 @@
+/**
+ * Local-timezone date helpers for the Cloudflare Worker backend.
+ *
+ * When an endpoint defaults to "today", we want the user's local today
+ * (e.g. "April 21" for a Pacific user at 10pm), not UTC today ("April 22").
+ * The request's `cf.timezone` field, populated by Cloudflare from the
+ * edge's geolocation of the client, gives us the IANA zone we need.
+ *
+ * Clients that pass an explicit `date=YYYY-MM-DD` still override this —
+ * the preferred pattern is frontend-sends-local-date, with this helper
+ * as a correctness backstop.
+ */
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * Derive a YYYY-MM-DD string in the user's local timezone from the Hono
+ * request context. Falls back to UTC if no timezone hint is available.
+ *
+ * @param {import('hono').Context} c
+ * @returns {string} YYYY-MM-DD
+ */
+export function todayForRequest(c) {
+  const tz = c?.req?.raw?.cf?.timezone || null;
+  return todayInTimezone(tz);
+}
+
+/**
+ * YYYY-MM-DD today in the given IANA timezone. Falls back to UTC if the
+ * zone is missing or unrecognized by the runtime's Intl DateTimeFormat.
+ */
+export function todayInTimezone(tz) {
+  const now = new Date();
+  if (!tz) {
+    return `${now.getUTCFullYear()}-${pad2(now.getUTCMonth() + 1)}-${pad2(now.getUTCDate())}`;
+  }
+  try {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+    }).formatToParts(now);
+    const y = parts.find((p) => p.type === 'year')?.value;
+    const m = parts.find((p) => p.type === 'month')?.value;
+    const d = parts.find((p) => p.type === 'day')?.value;
+    if (y && m && d) return `${y}-${m}-${d}`;
+  } catch (_) {
+    // fall through to UTC
+  }
+  return `${now.getUTCFullYear()}-${pad2(now.getUTCMonth() + 1)}-${pad2(now.getUTCDate())}`;
+}
+
+/**
+ * YYYY-MM-DD today minus (dayOffset) days in the user's local timezone.
+ * Negative offsets go into the past (e.g. -13 for the start of a 14-day
+ * inclusive window anchored on today).
+ */
+export function daysAgoForRequest(c, dayOffset) {
+  const todayStr = todayForRequest(c);
+  // Parse as local noon to avoid DST edge cases when subtracting days.
+  const [y, m, d] = todayStr.split('-').map(Number);
+  const anchor = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
+  anchor.setUTCDate(anchor.getUTCDate() + dayOffset);
+  return `${anchor.getUTCFullYear()}-${pad2(anchor.getUTCMonth() + 1)}-${pad2(anchor.getUTCDate())}`;
+}
+
+/**
+ * Normalize any input to YYYY-MM-DD:
+ *   - "2026-04-21"                         → "2026-04-21"
+ *   - "2026-04-21T22:00:00.000-07:00"      → "2026-04-21"
+ *   - "2026-04-21T22:00:00.000Z"           → "2026-04-21" (UTC date)
+ *   - Date instance                         → local date of that Date
+ *   - falsy                                 → null
+ */
+export function toDateKey(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
+  }
+  const s = String(value);
+  // Grab everything before a T or space (safe for local or UTC ISO forms)
+  const m = s.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (m) return m[1];
+  return null;
+}

--- a/tests/unit/local-date.test.js
+++ b/tests/unit/local-date.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  todayForRequest,
+  todayInTimezone,
+  daysAgoForRequest,
+  toDateKey
+} from '../../src/utils/local-date.js';
+
+/**
+ * Mock Hono context factory — only the `.raw.cf.timezone` field is
+ * actually read by our helpers, so that's all we stub.
+ */
+function mockCtx(timezone) {
+  return {
+    req: {
+      raw: {
+        cf: timezone === undefined ? undefined : { timezone }
+      }
+    }
+  };
+}
+
+describe('todayInTimezone', () => {
+  it('returns YYYY-MM-DD in the given IANA zone', () => {
+    const pacific = todayInTimezone('America/Los_Angeles');
+    expect(pacific).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('falls back to UTC when no timezone is given', () => {
+    const utc = todayInTimezone(null);
+    const now = new Date();
+    const expected = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+    expect(utc).toBe(expected);
+  });
+
+  it('falls back to UTC on an invalid timezone name', () => {
+    const fallback = todayInTimezone('Bogus/Not_A_Zone');
+    const now = new Date();
+    const expected = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+    expect(fallback).toBe(expected);
+  });
+
+  it('returns the correct local date at the UTC/local boundary', () => {
+    // Not testing exact values (date-dependent) — just that Pacific and
+    // UTC can disagree in the evening window. Verify by looking at the
+    // Intl output directly.
+    const utcNow = new Date();
+    const pacificStr = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/Los_Angeles',
+      year: 'numeric', month: '2-digit', day: '2-digit'
+    }).format(utcNow);
+    const helper = todayInTimezone('America/Los_Angeles');
+    expect(helper).toBe(pacificStr);
+  });
+});
+
+describe('todayForRequest', () => {
+  it('reads timezone from req.raw.cf.timezone', () => {
+    const c = mockCtx('America/Los_Angeles');
+    expect(todayForRequest(c)).toBe(todayInTimezone('America/Los_Angeles'));
+  });
+
+  it('falls back to UTC when cf object is missing', () => {
+    expect(todayForRequest(mockCtx(undefined))).toBe(todayInTimezone(null));
+  });
+
+  it('handles a null context without throwing', () => {
+    expect(() => todayForRequest(null)).not.toThrow();
+    expect(todayForRequest(null)).toBe(todayInTimezone(null));
+  });
+});
+
+describe('daysAgoForRequest', () => {
+  it('subtracts the given number of days from the local today', () => {
+    const c = mockCtx('America/Los_Angeles');
+    const today = todayForRequest(c);
+    const yesterday = daysAgoForRequest(c, -1);
+
+    const [y1, m1, d1] = today.split('-').map(Number);
+    const [y2, m2, d2] = yesterday.split('-').map(Number);
+    const t = new Date(Date.UTC(y1, m1 - 1, d1, 12));
+    const y = new Date(Date.UTC(y2, m2 - 1, d2, 12));
+    const diffDays = Math.round((t - y) / (24 * 60 * 60 * 1000));
+    expect(diffDays).toBe(1);
+  });
+
+  it('handles a 13-day window anchor (the activity feed default)', () => {
+    const c = mockCtx('America/Los_Angeles');
+    const today = todayForRequest(c);
+    const start = daysAgoForRequest(c, -13);
+
+    const [y1, m1, d1] = today.split('-').map(Number);
+    const [y2, m2, d2] = start.split('-').map(Number);
+    const t = new Date(Date.UTC(y1, m1 - 1, d1, 12));
+    const y = new Date(Date.UTC(y2, m2 - 1, d2, 12));
+    expect(Math.round((t - y) / (24 * 60 * 60 * 1000))).toBe(13);
+  });
+});
+
+describe('toDateKey', () => {
+  it('passes through YYYY-MM-DD strings unchanged', () => {
+    expect(toDateKey('2026-04-21')).toBe('2026-04-21');
+  });
+
+  it('strips everything after the T from an ISO string', () => {
+    expect(toDateKey('2026-04-21T22:30:00.000')).toBe('2026-04-21');
+    expect(toDateKey('2026-04-21T22:30:00.000-07:00')).toBe('2026-04-21');
+    expect(toDateKey('2026-04-21T22:30:00.000Z')).toBe('2026-04-21');
+  });
+
+  it('strips everything after a space (SQLite datetime form)', () => {
+    expect(toDateKey('2026-04-21 22:30:00')).toBe('2026-04-21');
+  });
+
+  it('returns a local YYYY-MM-DD for a Date object', () => {
+    const d = new Date(2026, 3, 21); // local April 21
+    expect(toDateKey(d)).toBe('2026-04-21');
+  });
+
+  it('returns null for falsy / non-date inputs', () => {
+    expect(toDateKey(null)).toBeNull();
+    expect(toDateKey(undefined)).toBeNull();
+    expect(toDateKey('')).toBeNull();
+    expect(toDateKey('not a date')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

User report: opening the Nutrition screen shows "April 22" as today even though the wall clock says April 21. Meals/entries logged in the evening (PT) were being filed under the wrong day, and the rings were reading tomorrow's empty log row.

Root cause: ~45 sites across the codebase computed "today" as `new Date().toISOString().split('T')[0]`, which returns UTC. For Western-Hemisphere users in the evening, UTC has rolled past midnight while they're still on the previous local day.

## Frontend — new helper module

`frontend/src/utils/date.js`:

| Helper | Returns |
|---|---|
| `todayLocal()` | YYYY-MM-DD in the browser's local tz |
| `dateLocal(d)` | YYYY-MM-DD from an arbitrary Date |
| `daysAgoLocal(offset)` | YYYY-MM-DD offset from local today |
| `nowLocalISO()` | naive local ISO (no Z, no offset) — for `logged_at` so SQLite's `date()` returns the local day |

Replaced every `toISOString().split('T')[0]` in the frontend across 7 files (nutrition screen, meal logger, saved meals, AI coach modals, workout calendar, past workout, export center).

## Backend — request-aware helper module

`src/utils/local-date.js`:

| Helper | Returns |
|---|---|
| `todayForRequest(c)` | reads `c.req.raw.cf.timezone` (populated by Cloudflare from client IP geolocation) and returns today in that zone; UTC fallback |
| `todayInTimezone(tz)` | same, but with an explicit zone |
| `daysAgoForRequest(c, offset)` | offset from local today |
| `toDateKey(value)` | normalizes any ISO / local / Date / SQLite datetime to YYYY-MM-DD |

Every "today default" in `src/routes/nutrition.js` + `src/routes/ai.js` now routes through this. Streak loops updated too so a streak that includes today doesn't get dropped by UTC skew.

## Tests

**14 new** in `tests/unit/local-date.test.js`:
- `todayInTimezone` with explicit zones + UTC fallback + invalid tz
- `todayForRequest` reads `req.raw.cf.timezone`, null-context safe
- `daysAgoForRequest` 1-day and 13-day offsets match expected wall-clock math
- `toDateKey` handles every shape (YYYY-MM-DD, ISO with/without offset, Z-ISO, SQLite space form, Date, falsy)

Full suite: **148 / 148 pass**. `wrangler deploy --dry-run` clean.

## Out of scope (noted, will address if it surfaces)

`src/services/achievements.js` still uses UTC for workout-streak calculations. Workout streaks at the midnight boundary could be slightly off — separate concern from the nutrition bug, can fix later.