### PR TITLE
Barcode 'Save' creates a Saved Meal (was: food favorite)

### DIFF
--- a/frontend/src/features/nutrition/meal-logger.js
+++ b/frontend/src/features/nutrition/meal-logger.js
@@ -811,8 +811,9 @@ async function lookupBarcode() {
                 <button class="btn btn-primary" id="scan-log-now" style="flex: 1;">
                   <i class="fas fa-check"></i> Log It
                 </button>
-                <button class="btn btn-outline" id="scan-save-favorite" title="Save this food to your Favorites">
-                  <i class="far fa-star"></i> Save
+                <button class="btn btn-outline" id="scan-save-meal"
+                        title="Save this product as a one-tap template in Saved Meals">
+                  <i class="fas fa-bookmark"></i> Save
                 </button>
               </div>
               <button class="btn btn-ghost btn-sm btn-block" id="scan-build-meal"
@@ -862,15 +863,46 @@ async function lookupBarcode() {
       }
     });
 
-    // 2) Save — toggle the food as a user favorite so it shows up in the
-    //    Favorites list on future meal logs, without creating a meal entry.
-    document.getElementById('scan-save-favorite')?.addEventListener('click', async () => {
+    // 2) Save — persist this product as a single-food Saved Meal template
+    //    so the user can one-tap log it again later from Saved Meals.
+    //    The backend de-dupes on (user_id, name), so re-scanning the same
+    //    item just refreshes its macros instead of creating duplicates.
+    document.getElementById('scan-save-meal')?.addEventListener('click', async () => {
+      const btn = document.getElementById('scan-save-meal');
+      const originalHTML = btn ? btn.innerHTML : '';
+      if (btn) {
+        btn.disabled = true;
+        btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving…';
+      }
       try {
         const toAdd = await ensureFoodPersisted(food);
-        const res = await api.post(`/nutrition/foods/${toAdd.id}/favorite`);
-        toast.success(res?.is_favorite ? 'Saved to Favorites' : 'Removed from Favorites');
+        const mealType = document.getElementById('scan-meal-type')?.value || defaultMealType;
+        const res = await api.post('/nutrition/saved-meals', {
+          name: toAdd.name,
+          meal_type: mealType,
+          // One-food template: copy per-serving macros from the food row.
+          foods: [{
+            food_id: toAdd.id,
+            custom_name: toAdd.name,
+            quantity: 1,
+            unit: 'serving',
+            calories: toAdd.calories || 0,
+            protein_g: toAdd.protein_g || 0,
+            carbs_g: toAdd.carbs_g || 0,
+            fat_g: toAdd.fat_g || 0,
+            fiber_g: toAdd.fiber_g || 0
+          }]
+        });
+        toast.success(res?.created === false
+          ? `Updated "${toAdd.name}" in Saved Meals`
+          : `Saved "${toAdd.name}" to Saved Meals`);
       } catch (err) {
         toast.error(`Error: ${err.message}`);
+      } finally {
+        if (btn) {
+          btn.disabled = false;
+          btn.innerHTML = originalHTML;
+        }
       }
     });
 

--- a/src/routes/nutrition.js
+++ b/src/routes/nutrition.js
@@ -2026,51 +2026,113 @@ nutrition.get('/saved-meals', async (c) => {
   return c.json({ saved_meals: meals.results || [] });
 });
 
-// Create a saved meal
+// Create or UPDATE a saved meal by name.
+//
+// De-dupes on (user_id, name) so the barcode-save flow (which calls this
+// with the scanned product's name) doesn't pile up duplicates when the
+// user re-scans the same item. If an existing saved meal matches, its
+// macros are overwritten, its saved_meal_foods are replaced, and the
+// existing row is returned with a `created: false` flag.
 nutrition.post('/saved-meals', async (c) => {
   const user = requireAuth(c);
   const body = await c.req.json();
   const db = c.env.DB;
-  
+
   const { name, description, meal_type, calories, protein_g, carbs_g, fat_g, fiber_g, recipe_url, foods } = body;
-  
+
   if (!name) {
     return c.json({ error: 'Meal name is required' }, 400);
   }
-  
-  // Calculate totals if foods provided
+
+  // If foods[] is provided, derive totals from them; otherwise use the
+  // macro fields from the body directly (quick-macro saved meals).
   let totalCalories = calories || 0;
   let totalProtein = protein_g || 0;
   let totalCarbs = carbs_g || 0;
   let totalFat = fat_g || 0;
   let totalFiber = fiber_g || 0;
-  
+
   if (foods && foods.length > 0) {
-    totalCalories = foods.reduce((sum, f) => sum + (f.calories || 0), 0);
-    totalProtein = foods.reduce((sum, f) => sum + (f.protein_g || 0), 0);
-    totalCarbs = foods.reduce((sum, f) => sum + (f.carbs_g || 0), 0);
-    totalFat = foods.reduce((sum, f) => sum + (f.fat_g || 0), 0);
-    totalFiber = foods.reduce((sum, f) => sum + (f.fiber_g || 0), 0);
+    totalCalories = foods.reduce((sum, f) => sum + (Number(f.calories) || 0), 0);
+    totalProtein = foods.reduce((sum, f) => sum + (Number(f.protein_g) || 0), 0);
+    totalCarbs = foods.reduce((sum, f) => sum + (Number(f.carbs_g) || 0), 0);
+    totalFat = foods.reduce((sum, f) => sum + (Number(f.fat_g) || 0), 0);
+    totalFiber = foods.reduce((sum, f) => sum + (Number(f.fiber_g) || 0), 0);
   }
-  
-  const meal = await db.prepare(
-    `INSERT INTO saved_meals (user_id, name, description, meal_type, calories, protein_g, carbs_g, fat_g, fiber_g, recipe_url)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-     RETURNING *`
-  ).bind(user.id, name, description || null, meal_type || 'any', totalCalories, totalProtein, totalCarbs, totalFat, totalFiber, recipe_url || null).first();
-  
-  // Add foods if provided
+
+  // Look for an existing saved meal with the same name for this user.
+  const existing = await db.prepare(
+    `SELECT * FROM saved_meals WHERE user_id = ? AND name = ? LIMIT 1`
+  ).bind(user.id, name).first();
+
+  let meal;
+  let created = true;
+
+  if (existing) {
+    // Update the existing saved meal's macros in place.
+    meal = await db.prepare(
+      `UPDATE saved_meals
+          SET description = COALESCE(?, description),
+              meal_type   = COALESCE(?, meal_type),
+              calories    = ?,
+              protein_g   = ?,
+              carbs_g     = ?,
+              fat_g       = ?,
+              fiber_g     = ?,
+              recipe_url  = COALESCE(?, recipe_url),
+              updated_at  = CURRENT_TIMESTAMP
+        WHERE id = ? AND user_id = ?
+        RETURNING *`
+    ).bind(
+      description || null,
+      meal_type || null,
+      totalCalories, totalProtein, totalCarbs, totalFat, totalFiber,
+      recipe_url || null,
+      existing.id, user.id
+    ).first();
+    created = false;
+
+    // Replace child foods so the saved meal's ingredients stay in sync
+    // with what the caller just sent.
+    await db.prepare(
+      `DELETE FROM saved_meal_foods WHERE saved_meal_id = ?`
+    ).bind(existing.id).run();
+  } else {
+    meal = await db.prepare(
+      `INSERT INTO saved_meals (user_id, name, description, meal_type, calories, protein_g, carbs_g, fat_g, fiber_g, recipe_url)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       RETURNING *`
+    ).bind(
+      user.id, name, description || null, meal_type || 'any',
+      totalCalories, totalProtein, totalCarbs, totalFat, totalFiber,
+      recipe_url || null
+    ).first();
+  }
+
   if (foods && foods.length > 0) {
     for (const food of foods) {
       await db.prepare(
         `INSERT INTO saved_meal_foods (saved_meal_id, food_id, custom_name, quantity, unit, calories, protein_g, carbs_g, fat_g)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      ).bind(meal.id, food.food_id || null, food.custom_name || null, food.quantity || 1, food.unit || 'serving',
-             food.calories || 0, food.protein_g || 0, food.carbs_g || 0, food.fat_g || 0).run();
+      ).bind(
+        meal.id,
+        food.food_id || null,
+        food.custom_name || null,
+        food.quantity || 1,
+        food.unit || 'serving',
+        Number(food.calories) || 0,
+        Number(food.protein_g) || 0,
+        Number(food.carbs_g) || 0,
+        Number(food.fat_g) || 0
+      ).run();
     }
   }
-  
-  return c.json({ saved_meal: meal, message: 'Meal saved' });
+
+  return c.json({
+    saved_meal: meal,
+    created,
+    message: created ? 'Meal saved' : 'Saved meal updated'
+  });
 });
 
 // Update a saved meal


### PR DESCRIPTION
## Summary

User reported: scanning a barcode and tapping **Save** didn't put the item in **Saved Meals** later. Correct — the button was actually calling `POST /nutrition/foods/:id/favorite`, which flips a flag on the *food* row so it appears in the meal-logger's Favorites list. That's a different feature from Saved Meals (one-tap meal templates).

Aligning the button with user intent confirmed via question prompt: **scan + Save should produce a single-food Saved Meal template** that can be re-logged with one tap later.

## Changes

### Frontend (`meal-logger.js`)

- Button icon flipped from `<star>` to `<bookmark>`, tooltip updated
- Handler renamed `scan-save-favorite` → `scan-save-meal`
- Now calls `POST /nutrition/saved-meals` with:
  - `name` = product name
  - `meal_type` = auto-detected or user-selected meal slot
  - `foods[0]` = single entry linking to the food row with per-serving macros
- Spinner + disabled state while saving, restored on completion
- Toast branches on the de-dupe result:
  - `Saved "Kellogg's Raisin Bran" to Saved Meals` (first time)
  - `Updated "Kellogg's Raisin Bran" in Saved Meals` (re-scan)

### Backend (`POST /nutrition/saved-meals`)

De-duped on `(user_id, name)` so re-scanning the same barcode doesn't stack duplicate Saved Meals:

1. `SELECT` existing `saved_meal` where `user_id = ? AND name = ?`
2. **Found** → `UPDATE` macros, `DELETE` child `saved_meal_foods`, re-insert from payload, return `{ created: false }`
3. **Not found** → `INSERT` fresh, return `{ created: true }`

Also tightened number coercion so string/null macros on inbound food items can't poison the saved meal's totals.

## Verification

Tests: **148/148 pass** (no new tests — DB-integration-only code path). Wrangler dry-run clean.

## How to use it after deploy

1. Scan a barcode → scan result card appears
2. Tap **Save** (bookmark icon)
3. Open **Saved Meals** → the product is there as a one-food template
4. Tap **Log** on it to add it to today's nutrition with one tap
5. Re-scan the same barcode later → Save just refreshes the macros, no duplicate template