### PR TITLE
Fix remaining timezone drift + persist USDA + click

### DIFF
--- a/frontend/src/features/nutrition/meal-logger.js
+++ b/frontend/src/features/nutrition/meal-logger.js
@@ -136,11 +136,10 @@ function attachHandlers(modalEl) {
     } else if (action === 'show-barcode') {
       showBarcodeScanner();
     } else if (action === 'select-food') {
-      const foodId = parseInt(target.getAttribute('data-food-id'), 10);
       const foodJson = target.getAttribute('data-food-json');
       if (foodJson) {
         try {
-          selectFood(JSON.parse(foodJson));
+          await selectFood(JSON.parse(foodJson));
         } catch (err) {
           console.error('Failed to parse food:', err);
         }
@@ -266,17 +265,44 @@ function renderResults(foods, source) {
   `);
 }
 
-function selectFood(food) {
+async function selectFood(food) {
   const quantity = 1;
   const unit = 'serving';
+
+  // USDA / Open Food Facts search results arrive with no `id` (they're
+  // not in our local `foods` table yet). Persist them NOW so they:
+  //   1) show up in local-DB search next time the user types a few letters
+  //   2) don't evaporate if the user closes the modal without tapping
+  //      "Save Meal" (the toast used to say "Added ${name}" which read
+  //      like a durable save — in reality the food was only in an
+  //      in-memory buffer)
+  // Already-local foods skip the round-trip.
+  let persisted = food;
+  if (!food.id && food.source) {
+    try {
+      persisted = await ensureFoodPersisted(food);
+    } catch (err) {
+      toast.error(`Couldn't save food: ${err.message}`);
+      return;
+    }
+  }
+
   state.selectedFoods.push({
-    food_id: food.id,
-    food,
+    food_id: persisted.id,
+    food: persisted,
     quantity,
     unit
   });
   updateSelectedFoodsDisplay();
-  toast.success(`Added ${food.name}`);
+
+  // Bring the "Selected Foods" card into view so the user sees their
+  // queued items and the Save Meal button at the bottom of the modal.
+  const totalsCard = document.getElementById('meal-totals-card');
+  if (totalsCard?.scrollIntoView) {
+    totalsCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  toast.success(`${persisted.name} added — tap Save Meal to log`);
 }
 
 function updateSelectedFoodsDisplay() {
@@ -935,7 +961,11 @@ export function quickAddFood(foodId, mealType = 'snack') {
     food_id: foodId,
     quantity: 1,
     unit: 'serving',
-    meal_type: mealType
+    meal_type: mealType,
+    // Always send the client's local date so the meal is filed under
+    // the right calendar day even if the backend's CF-timezone fallback
+    // misses.
+    date: todayLocal()
   }).then(() => {
     toast.success('Food added!');
     if (typeof window.loadNutrition === 'function') window.loadNutrition();

--- a/frontend/src/features/nutrition/saved-meals.js
+++ b/frontend/src/features/nutrition/saved-meals.js
@@ -265,7 +265,13 @@ export const updateSavedMeal = async (mealId) => {
 
 export async function logSavedMeal(mealId) {
   try {
-    await api.post(`/nutrition/saved-meals/${mealId}/log`);
+    // Always send the client's local date explicitly. The backend has a
+    // Cloudflare-timezone-aware fallback, but that's best-effort (VPNs,
+    // missing cf fields, etc.) — the browser knows for sure what day the
+    // user is on, so authoritative date = client date.
+    await api.post(`/nutrition/saved-meals/${mealId}/log`, {
+      date: todayLocal()
+    });
     toast.success('Meal logged!');
     if (typeof window.loadNutrition === 'function') window.loadNutrition();
   } catch (err) {
@@ -424,7 +430,13 @@ export function applyMacroPreset(calories, protein, carbs, fat) {
 
 async function logMacro(entryType, amount, unit) {
   try {
-    await api.post('/nutrition/entries', { entry_type: entryType, amount, unit });
+    await api.post('/nutrition/entries', {
+      entry_type: entryType, amount, unit,
+      // Stamp the entry with the user's local wall-clock time so it gets
+      // filed under today (not UTC-tomorrow if the user is west of GMT
+      // in the evening).
+      logged_at: nowLocalISO()
+    });
     toast.success('Logged!');
     if (typeof window.loadNutrition === 'function') window.loadNutrition();
   } catch (err) {
@@ -449,10 +461,11 @@ export async function logAllQuick() {
   }
 
   try {
+    const loggedAt = nowLocalISO();
     const ops = [];
-    if (protein > 0) ops.push(api.post('/nutrition/entries', { entry_type: 'protein', amount: protein, unit: 'g' }));
-    if (water > 0) ops.push(api.post('/nutrition/entries', { entry_type: 'water', amount: water, unit: 'ml' }));
-    if (creatine > 0) ops.push(api.post('/nutrition/entries', { entry_type: 'creatine', amount: creatine, unit: 'g' }));
+    if (protein > 0) ops.push(api.post('/nutrition/entries', { entry_type: 'protein', amount: protein, unit: 'g', logged_at: loggedAt }));
+    if (water > 0) ops.push(api.post('/nutrition/entries', { entry_type: 'water', amount: water, unit: 'ml', logged_at: loggedAt }));
+    if (creatine > 0) ops.push(api.post('/nutrition/entries', { entry_type: 'creatine', amount: creatine, unit: 'g', logged_at: loggedAt }));
     await Promise.all(ops);
 
     ['nq-protein', 'nq-water', 'nq-creatine'].forEach((id) => {


### PR DESCRIPTION
## Summary

Two user-reported issues after yesterday's PR #36:

1. **Meals still logging to April 22** when the user's local clock is April 21
2. **Searching USDA + tapping the `+` says the food was saved, but it never shows up anywhere**

## Root causes

### 1 — Three log paths still relied on the backend's CF-timezone fallback

PR #36 fixed all the obvious "today default" sites but left these sending no explicit date:

- `logSavedMeal()` → `POST /nutrition/saved-meals/:id/log`
- `logMacro()` (helper for `logProtein` / `logWater` / `logCreatine`)
- `logAllQuick()` in saved-meals.js
- `quickAddFood()` fallback helper

Backend falls back to `c.req.raw.cf.timezone`. When that field is missing (self-signed tunnels, some privacy proxies, local dev), it drops to UTC — which is tomorrow for late-evening Pacific users. The DB row landed on the wrong date even though the browser knew the right one.

**Fix:** every frontend log helper now stamps its request with either `date: todayLocal()` or `logged_at: nowLocalISO()`. The backend's CF-timezone fallback still exists, but it's truly a fallback now — **the browser is authoritative**.

### 2 — USDA `+` click only queued the food in-memory

USDA and Open Food Facts search results arrive with `id: null` (not in our local `foods` table yet). Clicking `+` pushed them to `state.selectedFoods` — a module-level in-memory buffer — and showed `toast.success('Added ${name}')`. If the user closed the modal without tapping **Save Meal**, the buffer was cleared and the food vanished. The toast wording made it sound durable when it wasn't.

**Fix:** `selectFood()` now persists inline USDA/OFF foods to the local `foods` table immediately, via `ensureFoodPersisted()` → `POST /nutrition/foods`. Effects:
- Next time the user types a few letters, local search will find the food (`foods.search` reads the `foods` table)
- Toast changed from `Added ${name}` to **`${name} added — tap Save Meal to log`** so the next step is explicit
- Modal scrolls to the **Selected Foods** card so the queue and **Save Meal** button are visible

## Verification

Tests: **148 / 148 pass**. `wrangler deploy --dry-run` clean.

## Files

- `frontend/src/features/nutrition/saved-meals.js` — logSavedMeal, logMacro, logAllQuick now send explicit local date / logged_at
- `frontend/src/features/nutrition/meal-logger.js` — selectFood persists inline foods; quickAddFood sends explicit date; clearer toast + scroll into view